### PR TITLE
fixed default history limit count error

### DIFF
--- a/readline.go
+++ b/readline.go
@@ -40,7 +40,7 @@ func (c *Config) Init() error {
 	if c.Stderr == nil {
 		c.Stderr = Stderr
 	}
-	if c.HistoryLimit < 0 {
+	if c.HistoryLimit <= 0 {
 		c.HistoryLimit = 500
 	}
 	return nil


### PR DESCRIPTION
The default history limit count will be 0 if cfg not set.
Which will make history lose efficacy.