### PR TITLE
Add delete home end support

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -108,6 +108,12 @@ func (t *Terminal) ioloop() {
 		} else if isEscapeEx {
 			isEscapeEx = false
 			r = escapeExKey(r)
+			// if hw delete button is pressed it is specified as set ot 4 runes [27,91,51,126]. we are now at 51
+			if r == CharDelete {
+				if d, _, err := buf.ReadRune(); err != nil || d != 126 {
+					buf.UnreadRune()
+				}
+			}
 		}
 
 		expectNextChar = true

--- a/terminal.go
+++ b/terminal.go
@@ -107,13 +107,7 @@ func (t *Terminal) ioloop() {
 			r = escapeKey(r)
 		} else if isEscapeEx {
 			isEscapeEx = false
-			r = escapeExKey(r)
-			// if hw delete button is pressed it is specified as set ot 4 runes [27,91,51,126]. we are now at 51
-			if r == CharDelete {
-				if d, _, err := buf.ReadRune(); err != nil || d != 126 {
-					buf.UnreadRune()
-				}
-			}
+			r = escapeExKey(r, buf)
 		}
 
 		expectNextChar = true

--- a/utils.go
+++ b/utils.go
@@ -43,7 +43,7 @@ func escapeExKey(r rune, reader *bufio.Reader) rune {
 	switch r {
 	case 51:
 		r = CharDelete
-		if d, _, err := reader.ReadRune(); err != nil || d != 126 {
+		if reader != nil && d, _, err := reader.ReadRune(); err != nil || d != 126 {
 			reader.UnreadRune()
 		}
 	case 'D':

--- a/utils.go
+++ b/utils.go
@@ -43,7 +43,7 @@ func escapeExKey(r rune, reader *bufio.Reader) rune {
 	switch r {
 	case 51:
 		r = CharDelete
-		if reader != nil && d, _, err := reader.ReadRune(); err != nil || d != 126 {
+		if d, _, err := reader.ReadRune(); reader != nil && (err != nil || d != 126) {
 			reader.UnreadRune()
 		}
 	case 'D':

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package readline
 
 import (
+	"bufio"
 	"strconv"
 	"syscall"
 
@@ -38,10 +39,13 @@ func IsPrintable(key rune) bool {
 }
 
 // translate Esc[X
-func escapeExKey(r rune) rune {
+func escapeExKey(r rune, reader *bufio.Reader) rune {
 	switch r {
 	case 51:
 		r = CharDelete
+		if d, _, err := reader.ReadRune(); err != nil || d != 126 {
+			reader.UnreadRune()
+		}
 	case 'D':
 		r = CharBackward
 	case 'C':

--- a/utils.go
+++ b/utils.go
@@ -40,6 +40,8 @@ func IsPrintable(key rune) bool {
 // translate Esc[X
 func escapeExKey(r rune) rune {
 	switch r {
+	case 51:
+		r = CharDeleteKey
 	case 'D':
 		r = CharBackward
 	case 'C':
@@ -48,6 +50,10 @@ func escapeExKey(r rune) rune {
 		r = CharPrev
 	case 'B':
 		r = CharNext
+	case 'H':
+		r = CharLineStart
+	case 'F':
+		r = CharLineEnd
 	}
 	return r
 }

--- a/utils.go
+++ b/utils.go
@@ -41,7 +41,7 @@ func IsPrintable(key rune) bool {
 func escapeExKey(r rune) rune {
 	switch r {
 	case 51:
-		r = CharDeleteKey
+		r = CharDelete
 	case 'D':
 		r = CharBackward
 	case 'C':


### PR DESCRIPTION
Added support for Delete key and Home/End keys
Tested on Ubuntu

Delete key is weird as it is specified by set of 4 runes (instead of 3 as with Home, End, or Ctrl + Anything combo). The seqence is 27 91 51 126

So workaround was made (in terminal.go) for this case, it checks whether Delete command was used (Ctrl + D or Delete key both returns CharDelete) and if so then it checks if next rune in buf is 126 if not it will put it back on top of the stack.