### PR TITLE
add stdin remapping support

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -330,7 +329,7 @@ func (o *Operation) Password(prompt string) ([]byte, error) {
 	o.t.EnterRawMode()
 	defer o.t.ExitRawMode()
 
-	b, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	b, err := terminal.ReadPassword(int(o.cfg.Stdin.Fd()))
 	fmt.Fprint(w, "\r\n")
 	return b, err
 }

--- a/readline.go
+++ b/readline.go
@@ -1,11 +1,19 @@
 package readline
 
-import "io"
+import (
+	"io"
+	"os"
+)
 
 type Instance struct {
 	Config    *Config
 	Terminal  *Terminal
 	Operation *Operation
+}
+
+type FdReader interface {
+	io.Reader
+	Fd() uintptr
 }
 
 type Config struct {
@@ -30,6 +38,7 @@ type Config struct {
 	InterruptPrompt string
 	EOFPrompt       string
 
+	Stdin  FdReader
 	Stdout io.Writer
 	Stderr io.Writer
 
@@ -46,6 +55,9 @@ func (c *Config) Init() error {
 		return nil
 	}
 	c.inited = true
+	if c.Stdin == nil {
+		c.Stdin = os.Stdin
+	}
 	if c.Stdout == nil {
 		c.Stdout = Stdout
 	}

--- a/terminal.go
+++ b/terminal.go
@@ -36,7 +36,7 @@ func NewTerminal(cfg *Config) (*Terminal, error) {
 }
 
 func (t *Terminal) EnterRawMode() (err error) {
-	t.state, err = MakeRaw(StdinFd)
+	t.state, err = MakeRaw(int(t.cfg.Stdin.Fd()))
 	return err
 }
 
@@ -44,7 +44,7 @@ func (t *Terminal) ExitRawMode() (err error) {
 	if t.state == nil {
 		return
 	}
-	err = Restore(StdinFd, t.state)
+	err = Restore(int(t.cfg.Stdin.Fd()), t.state)
 	if err == nil {
 		t.state = nil
 	}
@@ -91,7 +91,7 @@ func (t *Terminal) ioloop() {
 		expectNextChar bool
 	)
 
-	buf := bufio.NewReader(Stdin)
+	buf := bufio.NewReader(t.cfg.Stdin)
 	for {
 		if !expectNextChar {
 			atomic.StoreInt32(&t.isReading, 0)


### PR DESCRIPTION
This allows replacing Stdin with a socket other file interface as requested in #14. I'm using this in my [Usercorn project](https://github.com/lunixbochs/usercorn) for a remote debugging interface. I made the API use a new `FdReader` interface for Stdin in lieu of using `os.File` for ease of wrapping. The connecting client is expected to manually place stdin into raw mode.

This shouldn't break any existing features as it falls back to the global Stdin object for normal use.

Here's what the server-side looks like: https://github.com/lunixbochs/usercorn/blob/master/go/usercorn/debugger.go#L40

Here's the client-side (where I manually set raw mode on stdin): https://github.com/lunixbochs/usercorn/blob/master/go/usercorn/cli.go#L74