### PR TITLE
Fixed mass history

### DIFF
--- a/runebuf.go
+++ b/runebuf.go
@@ -360,7 +360,7 @@ func (r *RuneBuffer) output() []byte {
 }
 
 func (r *RuneBuffer) Reset() []rune {
-	ret := r.buf
+	ret := runes.Copy(r.buf)
 	r.buf = r.buf[:0]
 	r.idx = 0
 	return ret


### PR DESCRIPTION
#19 
The reason is the `Next()/Prev()` pass the real []rune out, which is a pointer, so when the `RuneBuf` update the []rune directly, it also will change the history item.