### PR TITLE
Fix a division by zero on terminals that report 0 width.

### DIFF
--- a/runebuf.go
+++ b/runebuf.go
@@ -320,7 +320,7 @@ func (r *RuneBuffer) MoveTo(ch rune, prevChar, reverse bool) (success bool) {
 func (r *RuneBuffer) IdxLine() int {
 	totalWidth := runes.WidthAll(r.buf[:r.idx]) + r.PromptLen()
 	w := getWidth(r.cfg.StdoutFd)
-	if w < 0 {
+	if w <= 0 {
 		return -1
 	}
 	line := totalWidth / w


### PR DESCRIPTION
This is true of emacs shell-mode.