### PR TITLE
add SetChildren for prefix completer interface

### DIFF
--- a/complete_helper.go
+++ b/complete_helper.go
@@ -12,6 +12,7 @@ type PrefixCompleterInterface interface {
 	Do(line []rune, pos int) (newLine [][]rune, length int)
 	GetName() []rune
 	GetChildren() []PrefixCompleterInterface
+	SetChildren(children []PrefixCompleterInterface)
 }
 
 type PrefixCompleter struct {
@@ -51,6 +52,10 @@ func (p *PrefixCompleter) GetName() []rune {
 
 func (p *PrefixCompleter) GetChildren() []PrefixCompleterInterface {
 	return p.Children
+}
+
+func (p *PrefixCompleter) SetChildren(children []PrefixCompleterInterface) {
+	p.Children = children
 }
 
 func NewPrefixCompleter(pc ...PrefixCompleterInterface) *PrefixCompleter {


### PR DESCRIPTION
In my case, I need update prefix completer in background, so I need this SetChildren method for prefix completer interface.

See the codes below, I need get server list first and then update the completer:
```
func updateServerList() {
	svrList, err := getServers()
	if err != nil {
		fmt.Fprintf(tty.Stderr(), "\r\nconnect to %s err: %s\r\n",
			color.Bold(framer), err)
	}
	if svrList == nil {
		return
	}

	updateCompleter(svrList)
}

func updateCompleter(svrList []string) {
	var tcServersCompleter []readline.PrefixCompleterInterface
	for _, host := range svrList {
		tcServersCompleter = append(tcServersCompleter, readline.PcItem(host))
	}
	for _, child := range completer.GetChildren() {
		childName := string(child.GetName())
		switch childName {
		case "setmaster ",
			"serveradd ",
			"serverstat ",
			"serverdel ",
			"serveroffline ",
			child.SetChildren(tcServersCompleter)
		default:
			continue
		}
	}
}
```