### PR TITLE
fixed

### DIFF
--- a/complete_helper.go
+++ b/complete_helper.go
@@ -3,6 +3,8 @@ package readline
 import (
 	"bytes"
 	"strings"
+
+	"github.com/chzyer/readline/runes"
 )
 
 type PrefixCompleterInterface interface {
@@ -73,7 +75,7 @@ func (p *PrefixCompleter) Do(line []rune, pos int) (newLine [][]rune, offset int
 }
 
 func Do(p PrefixCompleterInterface, line []rune, pos int) (newLine [][]rune, offset int) {
-	line = line[:pos]
+	line = runes.TrimSpaceLeft(line[:pos])
 	goNext := false
 	var lineCompleter PrefixCompleterInterface
 	for _, child := range p.GetChildren() {

--- a/runes.go
+++ b/runes.go
@@ -154,3 +154,14 @@ aggregate:
 	}
 	return
 }
+
+func TrimSpaceLeft(in []rune) []rune {
+	firstIndex := 0
+	for i, r := range in {
+		if unicode.IsSpace(r) == false {
+			firstIndex = i
+			break
+		}
+	}
+	return in[firstIndex:]
+}


### PR DESCRIPTION
readline does not provide auto-complete options when line is prefixed with some empty space(s).
Adding TrimSpaceLeft method for ignoring these spaces allows me to get auto-complete