### PR TITLE
Auto complete with space prefixed line

### DIFF
--- a/complete_helper.go
+++ b/complete_helper.go
@@ -73,7 +73,7 @@ func (p *PrefixCompleter) Do(line []rune, pos int) (newLine [][]rune, offset int
 }
 
 func Do(p PrefixCompleterInterface, line []rune, pos int) (newLine [][]rune, offset int) {
-	line = line[:pos]
+	line = runes.TrimSpaceLeft(line[:pos])
 	goNext := false
 	var lineCompleter PrefixCompleterInterface
 	for _, child := range p.GetChildren() {

--- a/example/readline-demo/readline-demo.go
+++ b/example/readline-demo/readline-demo.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/michalpristas/readline"
+	"github.com/chzyer/readline"
 )
 
 func usage(w io.Writer) {

--- a/example/readline-demo/readline-demo.go
+++ b/example/readline-demo/readline-demo.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chzyer/readline"
+	"github.com/michalpristas/readline"
 )
 
 func usage(w io.Writer) {

--- a/runes.go
+++ b/runes.go
@@ -154,3 +154,14 @@ aggregate:
 	}
 	return
 }
+
+func (Runes) TrimSpaceLeft(in []rune) []rune {
+	firstIndex := len(in)
+	for i, r := range in {
+		if unicode.IsSpace(r) == false {
+			firstIndex = i
+			break
+		}
+	}
+	return in[firstIndex:]
+}


### PR DESCRIPTION
fixed namespaces from previous pull request
problem was that with empty spaces (>0) prefixing the line auto-completer was not displayed after pressing tab key.