### PR TITLE
fix #36 vim mode: 'e' moves to the beginning of the next word

### DIFF
--- a/runebuf.go
+++ b/runebuf.go
@@ -259,6 +259,28 @@ func (r *RuneBuffer) MoveToNextWord() {
 	})
 }
 
+func (r *RuneBuffer) MoveToEndWord() {
+	r.Refresh(func() {
+		// already at the end, so do nothing
+		if r.idx == len(r.buf) {
+			return
+		}
+		// if we are at the end of a word already, go to next
+		if !IsWordBreak(r.buf[r.idx]) && IsWordBreak(r.buf[r.idx+1]) {
+			r.idx++
+		}
+
+		// keep going until at the end of a word
+		for i := r.idx + 1; i < len(r.buf); i++ {
+			if IsWordBreak(r.buf[i]) && !IsWordBreak(r.buf[i-1]) {
+				r.idx = i - 1
+				return
+			}
+		}
+		r.idx = len(r.buf)
+	})
+}
+
 func (r *RuneBuffer) BackEscapeWord() {
 	r.Refresh(func() {
 		if r.idx == 0 {

--- a/vim.go
+++ b/vim.go
@@ -74,8 +74,10 @@ func (o *opVim) handleVimNormalMovement(r rune, readNext func() rune) (t rune, h
 		}
 	case 'b', 'B':
 		rb.MoveToPrevWord()
-	case 'w', 'W', 'e', 'E':
+	case 'w', 'W':
 		rb.MoveToNextWord()
+	case 'e', 'E':
+		rb.MoveToEndWord()
 	case 'f', 'F', 't', 'T':
 		next := readNext()
 		prevChar := r == 't' || r == 'T'


### PR DESCRIPTION
I updated the switch in vim.go to treat 'w' and 'W' differently to 'e' and 'E'.

I then added a method to runebuf.go to provide the logic for that motion.
tested and working.