### PR TITLE
Fix: a backup plan when can't get size of terminal

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -58,10 +58,13 @@ func (o *opCompleter) nextCandidate(i int) {
 	}
 }
 
-func (o *opCompleter) OnComplete() {
+func (o *opCompleter) OnComplete() bool {
+	if o.width == 0 {
+		return false
+	}
 	if o.IsInCompleteSelectMode() {
 		o.doSelect()
-		return
+		return true
 	}
 
 	buf := o.op.buf
@@ -70,7 +73,7 @@ func (o *opCompleter) OnComplete() {
 	if o.IsInCompleteMode() && o.candidateSource != nil && runes.Equal(rs, o.candidateSource) {
 		o.EnterCompleteSelectMode()
 		o.doSelect()
-		return
+		return true
 	}
 
 	o.ExitCompleteSelectMode()
@@ -78,7 +81,7 @@ func (o *opCompleter) OnComplete() {
 	newLines, offset := o.op.cfg.AutoComplete.Do(rs, buf.idx)
 	if len(newLines) == 0 {
 		o.ExitCompleteMode(false)
-		return
+		return true
 	}
 
 	// only Aggregate candidates in non-complete mode
@@ -86,18 +89,19 @@ func (o *opCompleter) OnComplete() {
 		if len(newLines) == 1 {
 			buf.WriteRunes(newLines[0])
 			o.ExitCompleteMode(false)
-			return
+			return true
 		}
 
 		same, size := runes.Aggregate(newLines)
 		if size > 0 {
 			buf.WriteRunes(same)
 			o.ExitCompleteMode(false)
-			return
+			return true
 		}
 	}
 
 	o.EnterCompleteMode(offset, newLines)
+	return true
 }
 
 func (o *opCompleter) IsInCompleteSelectMode() bool {

--- a/operation.go
+++ b/operation.go
@@ -153,15 +153,26 @@ func (o *Operation) ioloop() {
 				o.t.Bell()
 				break
 			}
-			o.OnComplete()
-			keepInCompleteMode = true
+			if o.OnComplete() {
+				keepInCompleteMode = true
+			} else {
+				o.t.Bell()
+				break
+			}
+
 		case CharBckSearch:
-			o.SearchMode(S_DIR_BCK)
+			if !o.SearchMode(S_DIR_BCK) {
+				o.t.Bell()
+				break
+			}
 			keepInSearchMode = true
 		case CharCtrlU:
 			o.buf.KillFront()
 		case CharFwdSearch:
-			o.SearchMode(S_DIR_FWD)
+			if !o.SearchMode(S_DIR_FWD) {
+				o.t.Bell()
+				break
+			}
 			keepInSearchMode = true
 		case CharKill:
 			o.buf.Kill()
@@ -345,6 +356,7 @@ func (o *Operation) Runes() ([]rune, error) {
 	if o.cfg.Listener != nil {
 		o.cfg.Listener.OnChange(nil, 0, 0)
 	}
+
 	o.buf.Refresh(nil) // print prompt
 	o.t.KickRead()
 	select {

--- a/runebuf.go
+++ b/runebuf.go
@@ -411,9 +411,7 @@ func (r *RuneBuffer) SetOffset(offset string) {
 }
 
 func (r *RuneBuffer) print() {
-	if r.offset != "" {
-		r.w.Write(r.output())
-	}
+	r.w.Write(r.output())
 	r.hadClean = false
 }
 

--- a/runebuf.go
+++ b/runebuf.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"io"
 	"strings"
+	"sync"
 )
 
 type runeBufferBck struct {
@@ -25,6 +26,10 @@ type RuneBuffer struct {
 	width int
 
 	bck *runeBufferBck
+
+	offset string
+
+	sync.Mutex
 }
 
 func (r *RuneBuffer) OnWidthChange(newWidth int) {
@@ -370,6 +375,9 @@ func (r *RuneBuffer) getSplitByLine(rs []rune) []string {
 }
 
 func (r *RuneBuffer) IdxLine(width int) int {
+	if width == 0 {
+		return 0
+	}
 	sp := r.getSplitByLine(r.buf[:r.idx])
 	return len(sp) - 1
 }
@@ -379,12 +387,16 @@ func (r *RuneBuffer) CursorLineCount() int {
 }
 
 func (r *RuneBuffer) Refresh(f func()) {
+	r.Lock()
+	defer r.Unlock()
+
 	if !r.interactive {
 		if f != nil {
 			f()
 		}
 		return
 	}
+
 	r.Clean()
 	if f != nil {
 		f()
@@ -392,8 +404,16 @@ func (r *RuneBuffer) Refresh(f func()) {
 	r.print()
 }
 
+func (r *RuneBuffer) SetOffset(offset string) {
+	r.Lock()
+	r.offset = offset
+	r.Unlock()
+}
+
 func (r *RuneBuffer) print() {
-	r.w.Write(r.output())
+	if r.offset != "" {
+		r.w.Write(r.output())
+	}
 	r.hadClean = false
 }
 
@@ -473,15 +493,21 @@ func (r *RuneBuffer) SetPrompt(prompt string) {
 
 func (r *RuneBuffer) cleanOutput(w io.Writer, idxLine int) {
 	buf := bufio.NewWriter(w)
-	buf.Write([]byte("\033[J")) // just like ^k :)
 
-	if idxLine == 0 {
-		io.WriteString(buf, "\033[2K\r")
+	if r.width == 0 {
+		buf.WriteString(strings.Repeat("\r\b", len(r.buf)+r.PromptLen()))
+		buf.Write([]byte("\033[J"))
 	} else {
-		for i := 0; i < idxLine; i++ {
-			io.WriteString(buf, "\033[2K\r\033[A")
+		buf.Write([]byte("\033[J")) // just like ^k :)
+		if idxLine == 0 {
+			buf.WriteString("\033[2K")
+			buf.WriteString("\r")
+		} else {
+			for i := 0; i < idxLine; i++ {
+				io.WriteString(buf, "\033[2K\r\033[A")
+			}
+			io.WriteString(buf, "\033[2K\r")
 		}
-		io.WriteString(buf, "\033[2K\r")
 	}
 	buf.Flush()
 	return

--- a/search.go
+++ b/search.go
@@ -96,7 +96,10 @@ func (o *opSearch) SearchChar(r rune) {
 	o.search(true)
 }
 
-func (o *opSearch) SearchMode(dir int) {
+func (o *opSearch) SearchMode(dir int) bool {
+	if o.width == 0 {
+		return false
+	}
 	alreadyInMode := o.inMode
 	o.inMode = true
 	o.dir = dir
@@ -106,6 +109,7 @@ func (o *opSearch) SearchMode(dir int) {
 	} else {
 		o.SearchRefresh(-1)
 	}
+	return true
 }
 
 func (o *opSearch) ExitSearchMode(revert bool) {


### PR DESCRIPTION
ref: cockroachdb/cockroach/issues/8788

readline will run in some environment which the size of terminal is (0, 0).
According to the issue above, when `kubectl` and  server communicating with `protocolV2`, `pty` will stay in `0, 0` size and will not change anymore. In that case, readline can't work properly.

This PR will fix this case, without `search/complete` mode. When user trying to enter `search/complete` mode, the terminal will bell and do nothing.