### PR TITLE
Fix column padding calculation to prevent wrapping

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -219,7 +219,7 @@ func (o *opCompleter) CompleteRefresh() {
 		}
 		buf.WriteString(string(same))
 		buf.WriteString(string(c))
-		buf.Write(bytes.Repeat([]byte(" "), colWidth-len(c)))
+		buf.Write(bytes.Repeat([]byte(" "), colWidth-len(c)-len(same)))
 
 		if inSelect {
 			buf.WriteString("\033[0m")


### PR DESCRIPTION
The calculation to determine how many spaces to use when padding
columns wasn't taking into account the length of the 'same' portion of
the completions and was only using the length of the completion
itself. This frequently caused the printed completions to wrap, making
the completion list much harder to read.