### PR TITLE
Fix panic: runtime error: slice bounds out of range

### DIFF
--- a/example/readline-demo/readline-demo.go
+++ b/example/readline-demo/readline-demo.go
@@ -127,12 +127,11 @@ func main() {
 				println("you set:", strconv.Quote(string(pswd)))
 			}
 		case strings.HasPrefix(line, "setprompt"):
-			prompt := line[10:]
-			if prompt == "" {
+			if len(line) <= 10 {
 				log.Println("setprompt <prompt>")
 				break
 			}
-			l.SetPrompt(prompt)
+			l.SetPrompt(line[10:])
 		case strings.HasPrefix(line, "say"):
 			line := strings.TrimSpace(line[3:])
 			if len(line) == 0 {


### PR DESCRIPTION
Reslicing line[10:] went wrong if only 'setprompt' was entered, without a space after.