### PR TITLE
Prefill user input

### DIFF
--- a/readline.go
+++ b/readline.go
@@ -52,9 +52,10 @@ type Config struct {
 
 	FuncGetWidth func() int
 
-	Stdin  io.Reader
-	Stdout io.Writer
-	Stderr io.Writer
+	Stdin       io.Reader
+	StdinWriter io.Writer
+	Stdout      io.Writer
+	Stderr      io.Writer
 
 	EnableMask bool
 	MaskRune   rune
@@ -91,6 +92,9 @@ func (c *Config) Init() error {
 	if c.Stdin == nil {
 		c.Stdin = NewCancelableStdin(Stdin)
 	}
+
+	c.Stdin, c.StdinWriter = NewFillableStdin(c.Stdin)
+
 	if c.Stdout == nil {
 		c.Stdout = Stdout
 	}

--- a/readline.go
+++ b/readline.go
@@ -267,6 +267,20 @@ func (i *Instance) Write(b []byte) (int, error) {
 	return i.Stdout().Write(b)
 }
 
+// WriteStdin prefill the next Stdin fetch
+// Next time you call ReadLine() this value will be writen before the user input
+// ie :
+//  i := readline.New()
+//  i.WriteStdin([]byte("test"))
+//  _, _= i.Readline()
+//
+// gives
+//
+// > test[cursor]
+func (i *Instance) WriteStdin(val []byte) (int, error) {
+	return i.Terminal.WriteStdin(val)
+}
+
 func (i *Instance) SetConfig(cfg *Config) *Config {
 	if i.Config == cfg {
 		return cfg

--- a/std.go
+++ b/std.go
@@ -131,3 +131,60 @@ func (c *CancelableStdin) Close() error {
 	}
 	return nil
 }
+
+// FillableStdin is a stdin reader which can prepend some data before
+// reading into the real stdin
+type FillableStdin struct {
+	sync.Mutex
+	stdin       io.Reader
+	stdinBuffer io.Reader
+	buf         []byte
+	bufErr      error
+}
+
+// NewFillableStdin gives you FillableStdin
+func NewFillableStdin(stdin io.Reader) (io.Reader, io.Writer) {
+
+	r, w := io.Pipe()
+	s := &FillableStdin{
+		stdinBuffer: r,
+		stdin:       stdin,
+	}
+	s.ioloop()
+	return s, w
+
+}
+
+func (s *FillableStdin) ioloop() {
+	go func() {
+		for {
+			bufR := make([]byte, 100)
+			var n int
+			n, s.bufErr = s.stdinBuffer.Read(bufR)
+			s.Lock()
+			s.buf = append(s.buf, bufR[:n]...)
+			s.Unlock()
+		}
+	}()
+}
+
+// Read will read from the local buffer and if no data, read from stdin
+func (s *FillableStdin) Read(p []byte) (n int, err error) {
+	s.Lock()
+	i := len(s.buf)
+	if len(p) < i {
+		i = len(p)
+	}
+	if i > 0 {
+		n := copy(p, s.buf)
+		s.buf = s.buf[:0]
+		cerr := s.bufErr
+		s.bufErr = nil
+		s.Unlock()
+		return n, cerr
+	}
+	s.Unlock()
+
+	return s.stdin.Read(p)
+
+}

--- a/terminal.go
+++ b/terminal.go
@@ -65,6 +65,8 @@ func (t *Terminal) Write(b []byte) (int, error) {
 	return t.cfg.Stdout.Write(b)
 }
 
+// WriteStdin prefill the next Stdin fetch
+// Next time you call ReadLine() this value will be writen before the user input
 func (t *Terminal) WriteStdin(b []byte) (int, error) {
 	return t.cfg.StdinWriter.Write(b)
 }

--- a/terminal.go
+++ b/terminal.go
@@ -65,6 +65,10 @@ func (t *Terminal) Write(b []byte) (int, error) {
 	return t.cfg.Stdout.Write(b)
 }
 
+func (t *Terminal) WriteStdin(b []byte) (int, error) {
+	return t.cfg.StdinWriter.Write(b)
+}
+
 type termSize struct {
 	left int
 	top  int


### PR DESCRIPTION
This new feature allows to prefill user input with predefined response.
If you prefill with "foobar" the next time the library will do a ReadLine() you will have :

[prompt] > foobar[cursor here]

With foobar editable as the user input.