### PR TITLE
History can be disabled / enabled

### DIFF
--- a/history.go
+++ b/history.go
@@ -27,12 +27,14 @@ type opHistory struct {
 	current    *list.Element
 	fd         *os.File
 	fdLock     sync.Mutex
+	enable     bool
 }
 
 func newOpHistory(cfg *Config) (o *opHistory) {
 	o = &opHistory{
 		cfg:     cfg,
 		history: list.New(),
+		enable:  true,
 	}
 	return o
 }
@@ -223,6 +225,16 @@ func (o *opHistory) Next() ([]rune, bool) {
 	return runes.Copy(o.showItem(current.Value)), true
 }
 
+// Disable the current history
+func (o *opHistory) Disable() {
+	o.enable = false
+}
+
+// Enable the current history
+func (o *opHistory) Enable() {
+	o.enable = true
+}
+
 func (o *opHistory) debug() {
 	Debug("-------")
 	for item := o.history.Front(); item != nil; item = item.Next() {
@@ -232,6 +244,12 @@ func (o *opHistory) debug() {
 
 // save history
 func (o *opHistory) New(current []rune) (err error) {
+
+	// history deactivated
+	if !o.enable {
+		return nil
+	}
+
 	current = runes.Copy(current)
 
 	// if just use last command without modify

--- a/readline.go
+++ b/readline.go
@@ -277,3 +277,13 @@ func (i *Instance) SetConfig(cfg *Config) *Config {
 func (i *Instance) Refresh() {
 	i.Operation.Refresh()
 }
+
+// HistoryDisable the save of the commands into the history
+func (i *Instance) HistoryDisable() {
+	i.Operation.history.Disable()
+}
+
+// HistoryEnable the save of the commands into the history (default on)
+func (i *Instance) HistoryEnable() {
+	i.Operation.history.Enable()
+}


### PR DESCRIPTION
When you are doing an input with many informations across lines, sometimes you dont want the history to record them. This commit allows to disable/enable the history recording.