### PR TITLE
Ability to filter out input runes

### DIFF
--- a/example/readline-demo/readline-demo.go
+++ b/example/readline-demo/readline-demo.go
@@ -61,6 +61,15 @@ var completer = readline.NewPrefixCompleter(
 	readline.PcItem("sleep"),
 )
 
+func filterInput(r rune) (rune, bool) {
+	switch r {
+	// block CtrlZ feature
+	case readline.CharCtrlZ:
+		return r, false
+	}
+	return r, true
+}
+
 func main() {
 	l, err := readline.NewEx(&readline.Config{
 		Prompt:          "\033[31m»\033[0m ",
@@ -69,7 +78,8 @@ func main() {
 		InterruptPrompt: "^C",
 		EOFPrompt:       "exit",
 
-		HistorySearchFold: true,
+		HistorySearchFold:   true,
+		FuncFilterInputRune: filterInput,
 	})
 	if err != nil {
 		panic(err)

--- a/operation.go
+++ b/operation.go
@@ -96,6 +96,15 @@ func (o *Operation) ioloop() {
 		keepInSearchMode := false
 		keepInCompleteMode := false
 		r := o.t.ReadRune()
+		if o.cfg.FuncFilterInputRune != nil {
+			var process bool
+			r, process = o.cfg.FuncFilterInputRune(r)
+			if !process {
+				o.buf.Refresh(nil) // to refresh the line
+				continue           // ignore this rune
+			}
+		}
+
 		if r == 0 { // io.EOF
 			if o.buf.Len() == 0 {
 				o.buf.Clean()

--- a/readline.go
+++ b/readline.go
@@ -63,6 +63,10 @@ type Config struct {
 	// it use in IM usually.
 	UniqueEditLine bool
 
+	// filter input runes (may be used to disable CtrlZ or for translating some keys to different actions)
+	// -> output = new (translated) rune and true/false if continue with processing this one
+	FuncFilterInputRune func(rune) (rune, bool)
+
 	// force use interactive even stdout is not a tty
 	FuncIsTerminal      func() bool
 	FuncMakeRaw         func() error


### PR DESCRIPTION
Could be used to mask/disable some actions (like Ctrl-Z, or searching by Ctrl-R and Ctrl-S).

Examples in example/readline-demo/readline-demo.go updated to mask Ctrl-Z.