### PR TITLE
Add two API methods to set RuneBuffer state before prompting the user

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -32,6 +32,10 @@ type Operation struct {
 	*opVim
 }
 
+func (o *Operation) SetBuffer(what string) {
+	o.buf.Set([]rune(what))
+}
+
 type wrapWriter struct {
 	r      *Operation
 	t      *Terminal

--- a/readline.go
+++ b/readline.go
@@ -242,6 +242,11 @@ func (i *Instance) Readline() (string, error) {
 	return i.Operation.String()
 }
 
+func (i *Instance) ReadlineWithDefault(what string) (string, error) {
+	i.Operation.SetBuffer(what)
+	return i.Operation.String()
+}
+
 func (i *Instance) SaveHistory(content string) error {
 	return i.Operation.SaveHistory(content)
 }


### PR DESCRIPTION
I took a guess at API names. I also split this into two patches in case the first is worth grabbing and the second isn't.


`$ cat test.go`
```go
package main

import (
	"fmt"

	"github.com/chzyer/readline"
)

func main() {
	rl, err := readline.New("> ")
	if err != nil {
		panic(err)
	}
	line, err := rl.ReadlineWithDefault("default")
	if err != nil {
		panic(err)
	}
	fmt.Printf("%s\n", line)
}
```

```
$ go run test.go 
> default
default
```