### PR TITLE
intercept line rendering using a 'Painter'

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -502,3 +502,13 @@ func (d *DumpListener) OnChange(line []rune, pos int, key rune) (newLine []rune,
 type Listener interface {
 	OnChange(line []rune, pos int, key rune) (newLine []rune, newPos int, ok bool)
 }
+
+type Painter interface {
+	Paint(line []rune, pos int) []rune
+}
+
+type defaultPainter struct{}
+
+func (p *defaultPainter) Paint(line []rune, _ int) []rune {
+	return line
+}

--- a/readline.go
+++ b/readline.go
@@ -44,6 +44,8 @@ type Config struct {
 	// NOTE: Listener will be triggered by (nil, 0, 0) immediately
 	Listener Listener
 
+	Painter Painter
+
 	// If VimMode is true, readline will in vim.insert mode by default
 	VimMode bool
 
@@ -147,6 +149,10 @@ func (c Config) Clone() *Config {
 
 func (c *Config) SetListener(f func(line []rune, pos int, key rune) (newLine []rune, newPos int, ok bool)) {
 	c.Listener = FuncListener(f)
+}
+
+func (c *Config) SetPainter(p Painter) {
+	c.Painter = p
 }
 
 func NewEx(cfg *Config) (*Instance, error) {

--- a/runebuf.go
+++ b/runebuf.go
@@ -464,11 +464,11 @@ func (r *RuneBuffer) output() []byte {
 		}
 
 	} else {
-		for idx := range r.buf {
-			if r.buf[idx] == '\t' {
+		for _, e := range r.cfg.Painter.Paint(r.buf, r.idx) {
+			if e == '\t' {
 				buf.WriteString(strings.Repeat(" ", TabWidth))
 			} else {
-				buf.WriteRune(r.buf[idx])
+				buf.WriteRune(e)
 			}
 		}
 		if r.isInLineEdge() {


### PR DESCRIPTION
A Painter is tasked with producing an altered copy of the managed readline buffer for rendering purposes.  One example of its usage would be to perform real-time syntax highlighting of the edited string.