### PR TITLE
Fix panic for ReadPassword

### DIFF
--- a/password.go
+++ b/password.go
@@ -25,6 +25,7 @@ func (o *opPassword) PasswordConfig() *Config {
 		InterruptPrompt: "\n",
 		EOFPrompt:       "\n",
 		HistoryLimit:    -1,
+		Painter:         &defaultPainter{},
 
 		Stdout: o.o.cfg.Stdout,
 		Stderr: o.o.cfg.Stderr,


### PR DESCRIPTION
An issue on ishell https://github.com/abiosoft/ishell/issues/64 made me dig into this. I realized the panic is due to nil `Painter` for `Config` generated during `ReadPassword`.