### PR TITLE
Fix panic 'integer divide by zero' when terminal width too low

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -203,7 +203,9 @@ func (o *opCompleter) CompleteRefresh() {
 	// -1 to avoid reach the end of line
 	width := o.width - 1
 	colNum := width / colWidth
-	colWidth += (width - (colWidth * colNum)) / colNum
+	if colNum != 0 {
+		colWidth += (width - (colWidth * colNum)) / colNum
+	}
 
 	o.candidateColNum = colNum
 	buf := bufio.NewWriter(o.w)


### PR DESCRIPTION
In [awless](https://github.com/wallix/awless), when the terminal width is too low we get a panic in readline:

```
panic: runtime error: integer divide by zero

goroutine 24 [running]:
github.com/wallix/awless/vendor/github.com/chzyer/readline.(*opCompleter).CompleteRefresh(0xc4200a4460)
	/Users/fx/go_workspace/src/github.com/wallix/awless/vendor/github.com/chzyer/readline/complete.go:206 +0x88e
github.com/wallix/awless/vendor/github.com/chzyer/readline.(*opCompleter).EnterCompleteMode(0xc4200a4460, 0x0, 0xc4200ea300, 0x18, 0x20)
	/Users/fx/go_workspace/src/github.com/wallix/awless/vendor/github.com/chzyer/readline/complete.go:269 +0x61
github.com/wallix/awless/vendor/github.com/chzyer/readline.(*opCompleter).OnComplete(0xc4200a4460, 0xc420b58a20)
	/Users/fx/go_workspace/src/github.com/wallix/awless/vendor/github.com/chzyer/readline/complete.go:109 +0x25b
github.com/wallix/awless/vendor/github.com/chzyer/readline.(*Operation).ioloop(0xc4200a4150)
	/Users/fx/go_workspace/src/github.com/wallix/awless/vendor/github.com/chzyer/readline/operation.go:178 +0xf16
created by github.com/wallix/awless/vendor/github.com/chzyer/readline.NewOperation
	/Users/fx/go_workspace/src/github.com/wallix/awless/vendor/github.com/chzyer/readline/operation.go:88 +0x34d
```

This is due to the fact that terminal `width` gets lower than `colWidth`, so `colNum == 0`. This PR fixes this bug.