### PR TITLE
fix(runebuf): fix cursor move display problem

### DIFF
--- a/runebuf.go
+++ b/runebuf.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"github.com/mattn/go-runewidth"
 )
 
 type runeBufferBck struct {
@@ -528,7 +529,9 @@ func (r *RuneBuffer) getBackspaceSequence() []byte {
 	var buf []byte
 	for i := len(r.buf); i > r.idx; i-- {
 		// move input to the left of one
-		buf = append(buf, '\b')
+		rWidth := runewidth.RuneWidth(r.buf[i-1])
+		s := strings.Repeat("\b",rWidth)
+		buf = append(buf, []byte(s)...)
 		if sep[i] {
 			// up one line, go to the start of the line and move cursor right to the end (r.width)
 			buf = append(buf, "\033[A\r"+"\033["+strconv.Itoa(r.width)+"C"...)


### PR DESCRIPTION
The runebuf getBackspaceSequence method always prints a '\b' character,
but this is not enough for Chinese and other language characters,
add runewidth library to determine the character length.

My English is not very good, please see the picture:

No fix:

![old](https://user-images.githubusercontent.com/13043245/37810440-1484a81c-2e8f-11e8-9678-9f731d05b2f2.gif)

Fixed:

![kapture 2018-03-23 at 11 34 38](https://user-images.githubusercontent.com/13043245/37810320-5c95ee6e-2e8e-11e8-96f5-eb91077484ab.gif)


Signed-off-by: mritd <mritd1234@gmail.com>