### PR TITLE
runes: Treat Other Symbol (So) category as double width

### DIFF
--- a/runes.go
+++ b/runes.go
@@ -141,6 +141,7 @@ var doubleWidth = []*unicode.RangeTable{
 	unicode.Hangul,
 	unicode.Hiragana,
 	unicode.Katakana,
+	unicode.So,
 }
 
 func (Runes) Width(r rune) int {


### PR DESCRIPTION
This fixes issue of prompt width when one of the characters is from
the unicode 'Symbol, Other' (So) category such as '🐵'. The issue
is fixed by adding unicode.So to the double width range table.

Fixes #143