### PR TITLE
Modify the display width for Chinese characters and so on

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -221,7 +221,7 @@ func (o *opCompleter) CompleteRefresh() {
 		}
 		buf.WriteString(string(same))
 		buf.WriteString(string(c))
-		buf.Write(bytes.Repeat([]byte(" "), colWidth-len(c)-len(same)))
+		buf.Write(bytes.Repeat([]byte(" "), colWidth-runes.WidthAll(c)-runes.WidthAll(same)))
 
 		if inSelect {
 			buf.WriteString("\033[0m")


### PR DESCRIPTION
The display width will not be right if there have Chinese characters in the display. It will overflow the line, if the Chinese characters are at the end of a line. And makes "lines" value not the right number of line rows,  which makes "239: fmt.Fprintf" produce wrong output.