### PR TITLE
Support <Home>/<End> Keyboard keys for PuTTY

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -113,8 +113,13 @@ func escapeExKey(key *escapeKeyPair) rune {
 	case 'F':
 		r = CharLineEnd
 	case '~':
-		if key.attr == "3" {
+		switch key.attr {
+		case "1":
+			r = CharLineStart
+		case "3":
 			r = CharDelete
+		case "4":
+			r = CharLineEnd
 		}
 	default:
 	}


### PR DESCRIPTION
When my SSH and telnet client is PuTTY, the readline-demo can't parse \<Home\> and \<End\> Keyboard keys!!! It seems that "readline" can't adapt to old terminals very well.