### PR TITLE
Fix a race condition in terminal.go

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -35,6 +35,7 @@ func NewTerminal(cfg *Config) (*Terminal, error) {
 		sizeChan: make(chan string, 1),
 	}
 
+	t.wg.Add(1)
 	go t.ioloop()
 	return t, nil
 }
@@ -116,7 +117,6 @@ func (t *Terminal) KickRead() {
 }
 
 func (t *Terminal) ioloop() {
-	t.wg.Add(1)
 	defer func() {
 		t.wg.Done()
 		close(t.outchan)


### PR DESCRIPTION
There is a race condition in terminal.go relating to wait groups. The wg.Add method should be called by the parent goroutine, not the child.

https://golang.org/pkg/sync/#WaitGroup

This was caught by gotsan.

See #122 