### PR TITLE
Add support for Plan 9

### DIFF
--- a/term_plan9.go
+++ b/term_plan9.go
@@ -1,0 +1,28 @@
+package readline
+
+import "os"
+
+// State contains the state of a terminal.
+type State struct {
+	consctl *os.File
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd int) (*State, error) {
+	f, err := os.OpenFile("/dev/consctl", os.O_WRONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := f.WriteString("rawon"); err != nil {
+		return nil, err
+	}
+	return &State{consctl: f}, nil
+}
+
+// Restore restores the terminal connected to the given file descriptor to a
+// previous state.
+func restoreTerm(fd int, state *State) error {
+	return state.consctl.Close()
+}

--- a/utils_plan9.go
+++ b/utils_plan9.go
@@ -1,0 +1,44 @@
+package readline
+
+import (
+	"io"
+	"io/ioutil"
+	"strconv"
+	"syscall"
+)
+
+func SuspendMe() {
+}
+
+func GetScreenWidth() int {
+	const w = 0
+
+	// $COLS is set by vt(1). Read the environment variable directly
+	// because Go might be caching the value.
+	// See https://github.com/golang/go/issues/25234
+	b, err := ioutil.ReadFile("/env/COLS")
+	if err != nil {
+		return w
+	}
+	cols, err := strconv.Atoi(string(b))
+	if err != nil {
+		return w
+	}
+	return cols
+}
+
+// ClearScreen clears the console screen
+func ClearScreen(w io.Writer) (int, error) {
+	return w.Write([]byte("\033[H"))
+}
+
+func DefaultIsTerminal() bool {
+	return true
+}
+
+func GetStdin() int {
+	return syscall.Stdin
+}
+
+func DefaultOnWidthChanged(f func()) {
+}


### PR DESCRIPTION
This gets readline working within Plan 9's [vt(1)](https://9p.io/magic/man2html?man=vt&sect=1), which can emulate a VT–220, ANSI, or XTerm terminal.