### PR TITLE
Fix suggested by go vet

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -108,7 +108,7 @@ func (o *Operation) ioloop() {
 	for {
 		keepInSearchMode := false
 		keepInCompleteMode := false
-		r := o.t.ReadRune()
+		r, _, _ := o.t.ReadRune()
 		if o.GetConfig().FuncFilterInputRune != nil {
 			var process bool
 			r, process = o.GetConfig().FuncFilterInputRune(r)
@@ -154,7 +154,10 @@ func (o *Operation) ioloop() {
 		}
 
 		if o.IsEnableVimMode() {
-			r = o.HandleVim(r, o.t.ReadRune)
+			r = o.HandleVim(r, func() rune {
+				c, _, _ := o.t.ReadRune()
+				return c
+			})
 			if r == 0 {
 				continue
 			}

--- a/remote.go
+++ b/remote.go
@@ -182,7 +182,7 @@ loop:
 				break
 			}
 			n, err := ctx.msg.WriteTo(r.conn)
-			ctx.reply <- &writeReply{n, err}
+			ctx.reply <- &writeReply{int(n), err}
 		case <-r.stopChan:
 			break loop
 		}
@@ -273,13 +273,12 @@ func NewMessage(t MsgType, data []byte) *Message {
 	return &Message{t, data}
 }
 
-func (m *Message) WriteTo(w io.Writer) (int, error) {
+func (m *Message) WriteTo(w io.Writer) (int64, error) {
 	buf := bytes.NewBuffer(make([]byte, 0, len(m.Data)+2+4))
 	binary.Write(buf, binary.BigEndian, int32(len(m.Data)+2))
 	binary.Write(buf, binary.BigEndian, m.Type)
 	buf.Write(m.Data)
-	n, err := buf.WriteTo(w)
-	return int(n), err
+	return buf.WriteTo(w)
 }
 
 // -----------------------------------------------------------------------------

--- a/terminal.go
+++ b/terminal.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"unicode/utf8"
 )
 
 type Terminal struct {
@@ -96,12 +97,12 @@ func (t *Terminal) Readline() *Operation {
 }
 
 // return rune(0) if meet EOF
-func (t *Terminal) ReadRune() rune {
+func (t *Terminal) ReadRune() (rune, int, error) {
 	ch, ok := <-t.outchan
 	if !ok {
-		return rune(0)
+		return rune(0), 1, nil
 	}
-	return ch
+	return ch, utf8.RuneLen(ch), nil
 }
 
 func (t *Terminal) IsReading() bool {


### PR DESCRIPTION
Vet examines the source code and reports suspicious constructs including
non-standard signatures for widely-used names such as
WriteTo and ReadRune.

$ go vet github.com/chzyer/readline
remote.go:276: method WriteTo(w io.Writer) (int, error) should have signature WriteTo(io.Writer) (int64, error)
terminal.go:99: method ReadRune() rune should have signature ReadRune() (rune, int, error)

This commit introduces exported method changes.