### PR TITLE
Support arrows in Application mode

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -175,6 +175,14 @@ func escapeKey(r rune, reader *bufio.Reader) rune {
 	case 'O':
 		d, _, _ := reader.ReadRune()
 		switch d {
+		case 'D':
+			r = CharBackward
+		case 'C':
+			r = CharForward
+		case 'A':
+			r = CharPrev
+		case 'B':
+			r = CharNext
 		case 'H':
 			r = CharLineStart
 		case 'F':


### PR DESCRIPTION
In my terminal with zsh, arrow keys didn't work without this PR.

I think this PR fix #40 as well.