### PR TITLE
fix: Applied go fmt, fixed masked output

### DIFF
--- a/doc/shortcut.md
+++ b/doc/shortcut.md
@@ -1,40 +1,40 @@
 ## Readline Shortcut
 
-`Meta`+`B` means press `Esc` and `n` separately.  
-Users can change that in terminal simulator(i.e. iTerm2) to `Alt`+`B`  
+`Meta`+`B` means press `Esc` and `n` separately.
+Users can change that in terminal simulator(i.e. iTerm2) to `Alt`+`B`
 Notice: `Meta`+`B` is equals with `Alt`+`B` in windows.
 
 * Shortcut in normal mode
 
-| Shortcut           | Comment                           |
-| ------------------ | --------------------------------- |
-| `Ctrl`+`A`         | Beginning of line                 |
-| `Ctrl`+`B` / `←`   | Backward one character            |
-| `Meta`+`B`         | Backward one word                 |
-| `Ctrl`+`C`         | Send io.EOF                       |
-| `Ctrl`+`D`         | Delete one character              |
-| `Meta`+`D`         | Delete one word                   |
-| `Ctrl`+`E`         | End of line                       |
-| `Ctrl`+`F` / `→`   | Forward one character             |
-| `Meta`+`F`         | Forward one word                  |
-| `Ctrl`+`G`         | Cancel                            |
-| `Ctrl`+`H`         | Delete previous character         |
-| `Ctrl`+`I` / `Tab` | Command line completion           |
-| `Ctrl`+`J`         | Line feed                         |
-| `Ctrl`+`K`         | Cut text to the end of line       |
-| `Ctrl`+`L`         | Clear screen                      |
-| `Ctrl`+`M`         | Same as Enter key                 |
-| `Ctrl`+`N` / `↓`   | Next line (in history)            |
-| `Ctrl`+`P` / `↑`   | Prev line (in history)            |
-| `Ctrl`+`R`         | Search backwards in history       |
-| `Ctrl`+`S`         | Search forwards in history        |
-| `Ctrl`+`T`         | Transpose characters              |
-| `Meta`+`T`         | Transpose words (TODO)            |
-| `Ctrl`+`U`         | Cut text to the beginning of line |
-| `Ctrl`+`W`         | Cut previous word                 |
-| `Backspace`        | Delete previous character         |
-| `Meta`+`Backspace` | Cut previous word                 |
-| `Enter`            | Line feed                         |
+| Shortcut                  | Comment                           |
+| ------------------------- | --------------------------------- |
+| `Ctrl`+`A`                | Beginning of line                 |
+| `Ctrl`+`B` / `←`          | Backward one character            |
+| `Meta`+`B` / `Ctrl`+`←`   | Backward one word                 |
+| `Ctrl`+`C`                | Send io.EOF                       |
+| `Ctrl`+`D`                | Delete one character              |
+| `Meta`+`D`                | Delete one word                   |
+| `Ctrl`+`E`                | End of line                       |
+| `Ctrl`+`F` / `→`          | Forward one character             |
+| `Meta`+`F` / `Ctrl`+`→`   | Forward one word                  |
+| `Ctrl`+`G`                | Cancel                            |
+| `Ctrl`+`H`                | Delete previous character         |
+| `Ctrl`+`I` / `Tab`        | Command line completion           |
+| `Ctrl`+`J`                | Line feed                         |
+| `Ctrl`+`K`                | Cut text to the end of line       |
+| `Ctrl`+`L`                | Clear screen                      |
+| `Ctrl`+`M`                | Same as Enter key                 |
+| `Ctrl`+`N` / `↓`          | Next line (in history)            |
+| `Ctrl`+`P` / `↑`          | Prev line (in history)            |
+| `Ctrl`+`R`                | Search backwards in history       |
+| `Ctrl`+`S`                | Search forwards in history        |
+| `Ctrl`+`T`                | Transpose characters              |
+| `Meta`+`T`                | Transpose words (TODO)            |
+| `Ctrl`+`U`                | Cut text to the beginning of line |
+| `Ctrl`+`W`                | Cut previous word                 |
+| `Backspace`               | Delete previous character         |
+| `Meta`+`Backspace`        | Cut previous word                 |
+| `Enter`                   | Line feed                         |
 
 
 * Shortcut in Search Mode (`Ctrl`+`S` or `Ctrl`+`r` to enter this mode)

--- a/runebuf.go
+++ b/runebuf.go
@@ -35,7 +35,7 @@ type RuneBuffer struct {
 	sync.Mutex
 }
 
-func (r* RuneBuffer) pushKill(text []rune) {
+func (r *RuneBuffer) pushKill(text []rune) {
 	r.lastKill = append([]rune{}, text...)
 }
 
@@ -221,7 +221,7 @@ func (r *RuneBuffer) DeleteWord() {
 	}
 	for i := init + 1; i < len(r.buf); i++ {
 		if !IsWordBreak(r.buf[i]) && IsWordBreak(r.buf[i-1]) {
-			r.pushKill(r.buf[r.idx:i-1])
+			r.pushKill(r.buf[r.idx : i-1])
 			r.Refresh(func() {
 				r.buf = append(r.buf[:r.idx], r.buf[i-1:]...)
 			})
@@ -350,7 +350,7 @@ func (r *RuneBuffer) Yank() {
 		return
 	}
 	r.Refresh(func() {
-		buf := make([]rune, 0, len(r.buf) + len(r.lastKill))
+		buf := make([]rune, 0, len(r.buf)+len(r.lastKill))
 		buf = append(buf, r.buf[:r.idx]...)
 		buf = append(buf, r.lastKill...)
 		buf = append(buf, r.buf[r.idx:]...)
@@ -485,9 +485,6 @@ func (r *RuneBuffer) output() []byte {
 			buf.Write([]byte{'\n'})
 		} else {
 			buf.Write([]byte(string(r.cfg.MaskRune)))
-		}
-		if len(r.buf) > r.idx {
-			buf.Write(r.getBackspaceSequence())
 		}
 
 	} else {

--- a/utils.go
+++ b/utils.go
@@ -101,9 +101,17 @@ func escapeExKey(key *escapeKeyPair) rune {
 	var r rune
 	switch key.typ {
 	case 'D':
-		r = CharBackward
+		if key.attr == "1;5" {
+			r = MetaBackward
+		} else {
+			r = CharBackward
+		}
 	case 'C':
-		r = CharForward
+		if key.attr == "1;5" {
+			r = MetaForward
+		} else {
+			r = CharForward
+		}
 	case 'A':
 		r = CharPrev
 	case 'B':

--- a/utils.go
+++ b/utils.go
@@ -123,6 +123,12 @@ func escapeExKey(key *escapeKeyPair) rune {
 	case '~':
 		if key.attr == "3" {
 			r = CharDelete
+		} else if key.attr == "1" {
+			// If pressed "Home" go to line start
+			r = CharLineStart
+		} else if key.attr == "4" {
+			// If pressed "End" go to line end
+			r = CharLineEnd
 		}
 	default:
 	}


### PR DESCRIPTION
Lines 489-491 in runebuf.go are repeated in lines 506-508.
This typo led to working cursor through prompt text.
Deleting repeated lines fix that issue.
Applied go fmt to runebuf.go

* Masked output error
* Fmt