### PR TITLE
fix: Applied go fmt, fixed masked output

### DIFF
--- a/runebuf.go
+++ b/runebuf.go
@@ -35,7 +35,7 @@ type RuneBuffer struct {
 	sync.Mutex
 }
 
-func (r* RuneBuffer) pushKill(text []rune) {
+func (r *RuneBuffer) pushKill(text []rune) {
 	r.lastKill = append([]rune{}, text...)
 }
 
@@ -221,7 +221,7 @@ func (r *RuneBuffer) DeleteWord() {
 	}
 	for i := init + 1; i < len(r.buf); i++ {
 		if !IsWordBreak(r.buf[i]) && IsWordBreak(r.buf[i-1]) {
-			r.pushKill(r.buf[r.idx:i-1])
+			r.pushKill(r.buf[r.idx : i-1])
 			r.Refresh(func() {
 				r.buf = append(r.buf[:r.idx], r.buf[i-1:]...)
 			})
@@ -350,7 +350,7 @@ func (r *RuneBuffer) Yank() {
 		return
 	}
 	r.Refresh(func() {
-		buf := make([]rune, 0, len(r.buf) + len(r.lastKill))
+		buf := make([]rune, 0, len(r.buf)+len(r.lastKill))
 		buf = append(buf, r.buf[:r.idx]...)
 		buf = append(buf, r.lastKill...)
 		buf = append(buf, r.buf[r.idx:]...)
@@ -485,9 +485,6 @@ func (r *RuneBuffer) output() []byte {
 			buf.Write([]byte{'\n'})
 		} else {
 			buf.Write([]byte(string(r.cfg.MaskRune)))
-		}
-		if len(r.buf) > r.idx {
-			buf.Write(r.getBackspaceSequence())
 		}
 
 	} else {


### PR DESCRIPTION
Lines 489-491 in runebuf.go are repeated in lines 506-508.
This typo led to working cursor through prompt text.
Deleting repeated lines fix that issue.
Applied go fmt to runebuf.go

* Masked output error
* Fmt