### PR TITLE
AIX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <img src="https://raw.githubusercontent.com/chzyer/readline/assets/logo_f.png" />
 </p>
 
-A powerful readline library in `Linux` `macOS` `Windows` `Solaris`
+A powerful readline library in `Linux` `macOS` `Windows` `Solaris` `AIX`
 
 ## Guide
 

--- a/term.go
+++ b/term.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin dragonfly freebsd linux,!appengine netbsd openbsd solaris
+// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd solaris
 
 // Package terminal provides support functions for dealing with terminals, as
 // commonly found on UNIX systems.

--- a/term_nosyscall6.go
+++ b/term_nosyscall6.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build solaris
+// +build aix solaris
 
 package readline
 

--- a/utils_unix.go
+++ b/utils_unix.go
@@ -1,4 +1,4 @@
-// +build darwin dragonfly freebsd linux,!appengine netbsd openbsd solaris
+// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd solaris
 
 package readline
 


### PR DESCRIPTION
This commit adds support for AIX operating system.

 - move term_solaris.go to term_nosyscall6.go. AIX like solaris doesn't
provide syscall.Syscall6 and must rely on x/sys/unix in order to perform
syscalls.

 - This patch won't work with versions prior to 1.13 because it needs
some constants added by https://go-review.googlesource.com/c/go/+/171339.