### PR TITLE
Make <ctrl>+<left arrow> and <ctrl>+<right arrow> work

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -102,8 +102,14 @@ func escapeExKey(key *escapeKeyPair) rune {
 	switch key.typ {
 	case 'D':
 		r = CharBackward
+		if key.attr == "1;5" {
+			r = MetaBackward
+		}
 	case 'C':
 		r = CharForward
+		if key.attr == "1;5" {
+			r = MetaForward
+		}
 	case 'A':
 		r = CharPrev
 	case 'B':


### PR DESCRIPTION
On many systems <ctrl>+<left arrow> and <ctrl>+<right arrow> are mapped
to make the cursor move a word back and forward respectively. This is
done by mapping the `\e[1;5C` and `\e[1;5D` sequences.

This patch maps those sequences in this readline implementation as well.