### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: go
-go:
-  - 1.x
+matrix:
+   include:
+      - go: 1.x
+      - arch: ppc64le
+        go: 1.x
+        script:
+           - GOOS=linux go install github.com/chzyer/readline/example/...
+           - go test -race -v
 script:
   - GOOS=windows go install github.com/chzyer/readline/example/...
   - GOOS=linux go install github.com/chzyer/readline/example/...


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.