### PR TITLE
Option to restore terminal when interrupted

### DIFF
--- a/example/readline-demo/readline-demo.go
+++ b/example/readline-demo/readline-demo.go
@@ -80,6 +80,7 @@ func main() {
 
 		HistorySearchFold:   true,
 		FuncFilterInputRune: filterInput,
+		ExitRawOnInterrupt:  true,
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Add option ExitRawOnInterrupt (default off). When turned on, change
disposition of SIGTERM and SIGINT, so that we restore the terminal
mode before exiting. That way, prevents users from having to reset
the terminal themselves most of the time.