### PR TITLE
Fix race condition in DefaultOnWidthChanged

### DIFF
--- a/utils_unix.go
+++ b/utils_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || dragonfly || freebsd || (linux && !appengine) || netbsd || openbsd || solaris
 // +build darwin dragonfly freebsd linux,!appengine netbsd openbsd solaris
 
 package readline
@@ -60,11 +61,14 @@ func GetStdin() int {
 // -----------------------------------------------------------------------------
 
 var (
+	widthChangeMutex    sync.Mutex
 	widthChange         sync.Once
 	widthChangeCallback func()
 )
 
 func DefaultOnWidthChanged(f func()) {
+	widthChangeMutex.Lock()
+	defer widthChangeMutex.Unlock()
 	widthChangeCallback = f
 	widthChange.Do(func() {
 		ch := make(chan os.Signal, 1)


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x0000017ecc40 by goroutine 57:
  github.com/chzyer/readline.DefaultOnWidthChanged()
      /home/runner/go/pkg/mod/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e/utils_unix.go:68 +0x30
  github.com/chzyer/readline.NewOperation()
      /home/runner/go/pkg/mod/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e/operation.go:82 +0x84c
  github.com/chzyer/readline.(*Terminal).Readline()
      /home/runner/go/pkg/mod/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e/terminal.go:95 +0x5b
  github.com/chzyer/readline.NewEx()
      /home/runner/go/pkg/mod/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e/readline.go:167 +0x41
  github.com/manifoldco/promptui.(*Prompt).Run()
      /home/runner/go/pkg/mod/github.com/kylecarbs/promptui@v0.8.1-0.2020123[119](https://github.com/coder/coder/runs/5152098085?check_suite_focus=true#step:7:119)0244-d8f2159af2b2/prompt.go:142 +0x35a
  github.com/coder/coder/cli.prompt()
      /home/runner/work/coder/coder/cli/root.go:178 +0x9b2
  github.com/coder/coder/cli.projectCreate.func1()
      /home/runner/work/coder/coder/cli/projectcreate.go:44 +0x364
  github.com/spf13/cobra.(*Command).execute()
      /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:856 +0xa7d
  github.com/spf13/cobra.(*Command).ExecuteC()
      /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:974 +0x5da
  github.com/spf13/cobra.(*Command).Execute()
      /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902 +0x44
  github.com/coder/coder/cli_test.TestProjectCreate.func2.1()
      /home/runner/work/coder/coder/cli/projectcreate_test.go:83 +0x39

Previous write at 0x0000017ecc40 by goroutine 46:
  github.com/chzyer/readline.DefaultOnWidthChanged()
      /home/runner/go/pkg/mod/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e/utils_unix.go:68 +0x30
  github.com/chzyer/readline.NewOperation()
      /home/runner/go/pkg/mod/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e/operation.go:82 +0x84c
  github.com/chzyer/readline.(*Terminal).Readline()
      /home/runner/go/pkg/mod/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e/terminal.go:95 +0x5b
  github.com/chzyer/readline.NewEx()
      /home/runner/go/pkg/mod/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e/readline.go:167 +0x41
  github.com/manifoldco/promptui.(*Prompt).Run()
      /home/runner/go/pkg/mod/github.com/kylecarbs/promptui@v0.8.1-0.2020[123](https://github.com/coder/coder/runs/5152098085?check_suite_focus=true#step:7:123)1190244-d8f2[159](https://github.com/coder/coder/runs/5152098085?check_suite_focus=true#step:7:159)af2b2/prompt.go:142 +0x35a
  github.com/coder/coder/cli.prompt()
      /home/runner/work/coder/coder/cli/root.go:178 +0x9b2
  github.com/coder/coder/cli.projectCreate.func1()
      /home/runner/work/coder/coder/cli/projectcreate.go:44 +0x364
  github.com/spf13/cobra.(*Command).execute()
      /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:856 +0xa7d
  github.com/spf13/cobra.(*Command).ExecuteC()
      /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:974 +0x5da
  github.com/spf13/cobra.(*Command).Execute()
      /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902 +0x44
  github.com/coder/coder/cli_test.TestProjectCreate.func1.1()
      /home/runner/work/coder/coder/cli/projectcreate_test.go:34 +0x39
```