### PR TITLE
Various screen redraw fixes for wide characters, narrow screens etc.

### DIFF
--- a/ansi_windows.go
+++ b/ansi_windows.go
@@ -122,7 +122,7 @@ func (a *ANSIWriterCtx) ioloopEscSeq(w *bufio.Writer, r rune, argptr *[]string) 
 	arg := *argptr
 	var err error
 
-	if r >= 'A' && r <= 'D' {
+	if (r >= 'A' && r <= 'D') || r == 'G' {
 		count := short(GetInt(arg, 1))
 		info, err := GetConsoleScreenBufferInfo()
 		if err != nil {
@@ -137,6 +137,8 @@ func (a *ANSIWriterCtx) ioloopEscSeq(w *bufio.Writer, r rune, argptr *[]string) 
 			info.dwCursorPosition.x += count
 		case 'D': // left
 			info.dwCursorPosition.x -= count
+		case 'G': // Absolute horizontal position
+			info.dwCursorPosition.x = count - 1 // windows origin is 0, unix is 1
 		}
 		SetConsoleCursorPosition(&info.dwCursorPosition)
 		return false

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/chzyer/test v1.0.0
 	golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5
+	golang.org/x/text v0.3.7
 )
 
 require github.com/chzyer/logex v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,6 @@ github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 h1:y/woIyUBFbpQGKS0u1aHF/40WUDnek3fPOyD08H5Vng=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/operation.go
+++ b/operation.go
@@ -232,6 +232,7 @@ func (o *Operation) ioloop() {
 			o.Refresh()
 		case CharCtrlL:
 			ClearScreen(o.w)
+			o.buf.SetOffset("1;1")
 			o.Refresh()
 		case MetaBackspace, CharCtrlW:
 			o.buf.BackEscapeWord()
@@ -385,8 +386,14 @@ func (o *Operation) Runes() ([]rune, error) {
 		listener.OnChange(nil, 0, 0)
 	}
 
-	o.buf.Refresh(nil) // print prompt
+	// Query cursor position before printing the prompt as there
+	// maybe existing text on the same line that ideally we don't
+	// want to overwrite and cause prompt to jump left. Note that
+	// this is not perfect but works the majority of the time.
+	o.buf.getAndSetOffset(o.t)
+	o.buf.Print() // print prompt & buffer contents
 	o.t.KickRead()
+
 	select {
 	case r := <-o.outchan:
 		return r, nil

--- a/runes.go
+++ b/runes.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"unicode"
 	"unicode/utf8"
+	"golang.org/x/text/width"
 )
 
 var runes = Runes{}
@@ -150,10 +151,12 @@ func (Runes) Width(r rune) int {
 	if unicode.IsOneOf(zeroWidth, r) {
 		return 0
 	}
-	if unicode.IsOneOf(doubleWidth, r) {
+	switch width.LookupRune(r).Kind() {
+	case width.EastAsianWide, width.EastAsianFullwidth:
 		return 2
+	default:
+		return 1
 	}
-	return 1
 }
 
 func (Runes) WidthAll(r []rune) (length int) {

--- a/runes_test.go
+++ b/runes_test.go
@@ -10,16 +10,52 @@ type twidth struct {
 	length int
 }
 
+func TestSingleRuneWidth(t *testing.T) {
+        type test struct {
+                r  rune
+                w  int
+        }
+
+        tests := []test{
+		{0, 0},             // default rune is 0 - default mask
+		{'a', 1},
+		{'☭', 1},
+		{'你', 2},
+		{'日', 2},          // kanji
+		{'ｶ', 1},           // half-width katakana
+		{'カ', 2},          // full-width katakana
+		{'ひ', 2},          // full-width hiragana 
+		{'Ｗ', 2},          // full-width romanji
+		{'）', 2},          // full-width symbols
+		{'😅', 2},          // emoji
+        }
+
+        for _, test := range tests {
+		if w := runes.Width(test.r); w != test.w {
+			t.Error("result is not expected", string(test.r), test.w, w)
+		}
+	}
+}
+
 func TestRuneWidth(t *testing.T) {
 	rs := []twidth{
+		{[]rune(""), 0},
 		{[]rune("☭"), 1},
 		{[]rune("a"), 1},
 		{[]rune("你"), 2},
 		{runes.ColorFilter([]rune("☭\033[13;1m你")), 3},
+		{[]rune("漢字"), 4},           // kanji
+		{[]rune("ｶﾀｶﾅ"), 4},           // half-width katakana
+		{[]rune("カタカナ"), 8},       // full-width katakana
+		{[]rune("ひらがな"), 8},       // full-width hiragana 
+		{[]rune("ＷＩＤＥ"), 8},       // full-width romanji
+		{[]rune("ー。"), 4},           // full-width symbols
+		{[]rune("안녕하세요"), 10},    // full-width Hangul
+		{[]rune("😅"), 2},             // emoji
 	}
 	for _, r := range rs {
 		if w := runes.WidthAll(r.r); w != r.length {
-			t.Fatal("result not expect", r.r, r.length, w)
+			t.Error("result is not expected", string(r.r), r.length, w)
 		}
 	}
 }

--- a/terminal.go
+++ b/terminal.go
@@ -80,7 +80,7 @@ func (t *Terminal) GetOffset(f func(offset string)) {
 	go func() {
 		f(<-t.sizeChan)
 	}()
-	t.Write([]byte("\033[6n"))
+	SendCursorPosition(t)
 }
 
 func (t *Terminal) Print(s string) {

--- a/utils.go
+++ b/utils.go
@@ -190,21 +190,29 @@ func escapeKey(r rune, reader *bufio.Reader) rune {
 	return r
 }
 
-func SplitByLine(start, screenWidth int, rs []rune) []string {
-	var ret []string
-	buf := bytes.NewBuffer(nil)
-	currentWidth := start
-	for _, r := range rs {
+// split prompt + runes into lines by screenwidth starting from an offset.
+// the prompt should be filtered before passing to only its display runes.
+// if you know the width of the next character, pass it in as it is used
+// to decide if we generate an extra empty rune array to show next is new
+// line.
+func SplitByLine(prompt, rs []rune, offset, screenWidth, nextWidth int) [][]rune {
+	ret := make([][]rune, 0)
+	prs := append(prompt, rs...)
+	si := 0
+	currentWidth := offset
+	for i, r := range prs {
 		w := runes.Width(r)
-		currentWidth += w
-		buf.WriteRune(r)
-		if currentWidth >= screenWidth {
-			ret = append(ret, buf.String())
-			buf.Reset()
+		if currentWidth + w > screenWidth {
+			ret = append(ret, prs[si:i])
+			si = i
 			currentWidth = 0
 		}
+		currentWidth += w
 	}
-	ret = append(ret, buf.String())
+	ret = append(ret, prs[si:len(prs)])
+	if currentWidth + nextWidth > screenWidth {
+		ret = append(ret, []rune{})
+	}
 	return ret
 }
 

--- a/utils_unix.go
+++ b/utils_unix.go
@@ -44,6 +44,12 @@ func GetScreenWidth() int {
 	return w
 }
 
+// Ask the terminal for the current cursor position. The terminal will then
+// write the position back to us via termainal stdin asynchronously.
+func SendCursorPosition(t *Terminal) {
+	t.Write([]byte("\033[6n"))
+}
+
 // ClearScreen clears the console screen
 func ClearScreen(w io.Writer) (int, error) {
 	return w.Write([]byte("\033[H"))

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -3,6 +3,7 @@
 package readline
 
 import (
+	"fmt"
 	"io"
 	"syscall"
 )
@@ -25,6 +26,16 @@ func GetScreenWidth() int {
 		return -1
 	}
 	return int(info.dwSize.x)
+}
+
+// Send the Current cursor position to t.sizeChan.
+func SendCursorPosition(t *Terminal) {
+	info, err := GetConsoleScreenBufferInfo()
+	if err != nil || info == nil {
+		t.sizeChan <- "-1;-1"
+	} else {
+		t.sizeChan <- fmt.Sprintf("%d;%d", info.dwCursorPosition.y, info.dwCursorPosition.x)
+	}
 }
 
 // ClearScreen clears the console screen


### PR DESCRIPTION
- Don't overwrite existing text on same line as the prompt
- Don't refresh screen when simply appending characters to buffer
- Don't refresh screen unnessarily when pressing enter key
- Handle prompts longer than screen width.
- Fix wide characters in prompt
- Fix screen edge issue when next character is wide.
- Fix screen edge issue for masked characters
- Fix narrow masked characteter, masking wide input
- Fix wide masked character, masking narrow input
- Reworked backspacesequence for index to use same algorithm as used
  for lineedge and reduce the control sequences to 2.
- Reworked cleanup to incorporate initial cursor column position
  and avoid overwriting existing text as well as simplifying the
  control sequences used.
- Fixed double width character detection and updated unit tests
- Handle emoji in text or prompts.
- Implement windows ANSI absolute horizonal position ansi code.
- Get windows cursor position directly and don't send ansi DSR code
- Don't write out empty mask runes
- Cleanup - removed unused hadCLean variable