### PR TITLE
fix(autocomplete newline): autocomplete newline

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -209,7 +209,7 @@ func (o *opCompleter) CompleteRefresh() {
 
 	o.candidateColNum = colNum
 	buf := bufio.NewWriter(o.w)
-	buf.Write(bytes.Repeat([]byte("\n"), lineCnt))
+	buf.Write(bytes.Repeat([]byte("\n\r"), lineCnt))
 
 	colIdx := 0
 	lines := 1


### PR DESCRIPTION
Print autocompletion keywords starting on a new line.
\n is only newline, \r is to move the cursor to the beginning of the line.

only \n
<img width="1878" alt="image" src="https://user-images.githubusercontent.com/16531687/175313830-cfd68ab4-042d-4ee0-93e4-8b2fe0f23572.png">

\n\r
<img width="1664" alt="image" src="https://user-images.githubusercontent.com/16531687/175314030-64119bda-9211-4bfb-a791-047faba124d8.png">
