### PR TITLE
Tab Completion Candidate Pager for when candidates don't fit on a single page

### DIFF
--- a/ansi_windows.go
+++ b/ansi_windows.go
@@ -122,7 +122,7 @@ func (a *ANSIWriterCtx) ioloopEscSeq(w *bufio.Writer, r rune, argptr *[]string) 
 	arg := *argptr
 	var err error
 
-	if r >= 'A' && r <= 'D' {
+	if (r >= 'A' && r <= 'D') || r == 'G' {
 		count := short(GetInt(arg, 1))
 		info, err := GetConsoleScreenBufferInfo()
 		if err != nil {
@@ -137,6 +137,8 @@ func (a *ANSIWriterCtx) ioloopEscSeq(w *bufio.Writer, r rune, argptr *[]string) 
 			info.dwCursorPosition.x += count
 		case 'D': // left
 			info.dwCursorPosition.x -= count
+		case 'G': // Absolute horizontal position
+			info.dwCursorPosition.x = count - 1 // windows origin is 0, unix is 1
 		}
 		SetConsoleCursorPosition(&info.dwCursorPosition)
 		return false

--- a/complete.go
+++ b/complete.go
@@ -25,24 +25,29 @@ func (t *TabCompleter) Do([]rune, int) ([][]rune, int) {
 }
 
 type opCompleter struct {
-	w     io.Writer
-	op    *Operation
-	width int
+	w               io.Writer
+	op              *Operation
+	width           int
+	height          int
 
 	inCompleteMode  bool
 	inSelectMode    bool
-	candidate       [][]rune
-	candidateSource []rune
-	candidateOff    int
-	candidateChoise int
-	candidateColNum int
+	inPagerMode	bool
+
+	candidate          [][]rune      // list of candidates
+	candidateSource    []rune        // buffer string when tab was pressed
+	candidateOff       int           // num runes in common from buf where candidate start
+	candidateChoise    int           // candidate chosen (-1 for nothing yet) also used for paging
+	candidateColNum    int           // num columns candidates take 0..wraps, 1 col, 2 cols etc.
+	candidateColWidth  int           // width of candidate columns
 }
 
-func newOpCompleter(w io.Writer, op *Operation, width int) *opCompleter {
+func newOpCompleter(w io.Writer, op *Operation, width, height int) *opCompleter {
 	return &opCompleter{
-		w:     w,
-		op:    op,
-		width: width,
+		w:      w,
+		op:     op,
+		width:  width,
+		height: height,
 	}
 }
 
@@ -64,8 +69,11 @@ func (o *opCompleter) nextCandidate(i int) {
 	}
 }
 
-func (o *opCompleter) OnComplete() bool {
-	if o.width == 0 {
+// OnComplete returns true if complete mode is available. Used to ring bell
+// when tab pressed if cannot do complete for reason such as width unknown
+// or no candidates available.
+func (o *opCompleter) OnComplete() (ringBell bool) {
+	if o.width == 0 || o.height < 3 {
 		return false
 	}
 	if o.IsInCompleteSelectMode() {
@@ -76,36 +84,54 @@ func (o *opCompleter) OnComplete() bool {
 	buf := o.op.buf
 	rs := buf.Runes()
 
+	// If in complete mode and nothing else typed then we must be entering select mode
 	if o.IsInCompleteMode() && o.candidateSource != nil && runes.Equal(rs, o.candidateSource) {
+		if len(o.candidate) > 1 {
+			same, size := runes.Aggregate(o.candidate)
+			if size > 0 {
+				buf.WriteRunes(same)
+				o.ExitCompleteMode(false)
+				return false  // partial completion so ring the bell
+			}
+		}
 		o.EnterCompleteSelectMode()
 		o.doSelect()
 		return true
 	}
 
-	o.ExitCompleteSelectMode()
-	o.candidateSource = rs
 	newLines, offset := o.op.cfg.AutoComplete.Do(rs, buf.idx)
-	if len(newLines) == 0 {
+	if len(newLines) == 0 || (len(newLines) == 1 && len(newLines[0]) == 0) {
+		o.ExitCompleteMode(false)
+		return false // will ring bell on initial tab press
+	} 
+	if o.candidateOff > offset {
+		// part of buffer we are completing has changed. Example might be that we were completing "ls" and
+		// user typed space so we are no longer completing "ls" but now we are completing an argument of
+		// the ls command. Instead of continuing in complete mode, we exit.
 		o.ExitCompleteMode(false)
 		return true
 	}
+	o.candidateSource = rs
 
 	// only Aggregate candidates in non-complete mode
 	if !o.IsInCompleteMode() {
 		if len(newLines) == 1 {
+			// not yet in complete mode but only 1 candidate so complete it
 			buf.WriteRunes(newLines[0])
 			o.ExitCompleteMode(false)
 			return true
 		}
 
+		// check if all candidates have common prefix and return it and its size
 		same, size := runes.Aggregate(newLines)
 		if size > 0 {
 			buf.WriteRunes(same)
 			o.ExitCompleteMode(false)
-			return true
+			return false  // partial completion so ring the bell
 		}
 	}
 
+	// otherwise, we just enter complete mode (which does a refresh)
 	o.EnterCompleteMode(offset, newLines)
 	return true
 }
@@ -118,7 +144,11 @@ func (o *opCompleter) IsInCompleteMode() bool {
 	return o.inCompleteMode
 }
 
-func (o *opCompleter) HandleCompleteSelect(r rune) bool {
+func (o *opCompleter) IsInPagerMode() bool {
+	return o.inPagerMode
+}
+
+func (o *opCompleter) HandleCompleteSelect(r rune) (stayInMode bool) {
 	next := true
 	switch r {
 	case CharEnter, CharCtrlJ:
@@ -126,39 +156,51 @@ func (o *opCompleter) HandleCompleteSelect(r rune) bool {
 		o.op.buf.WriteRunes(o.op.candidate[o.op.candidateChoise])
 		o.ExitCompleteMode(false)
 	case CharLineStart:
-		num := o.candidateChoise % o.candidateColNum
-		o.nextCandidate(-num)
+		if o.candidateColNum > 1 {
+			num := o.candidateChoise % o.candidateColNum
+			o.nextCandidate(-num)
+		}
 	case CharLineEnd:
-		num := o.candidateColNum - o.candidateChoise%o.candidateColNum - 1
-		o.candidateChoise += num
-		if o.candidateChoise >= len(o.candidate) {
-			o.candidateChoise = len(o.candidate) - 1
+		if o.candidateColNum > 1 {
+			num := o.candidateColNum - o.candidateChoise % o.candidateColNum - 1
+			o.candidateChoise += num
+			if o.candidateChoise >= len(o.candidate) {
+				o.candidateChoise = len(o.candidate) - 1
+			}
 		}
 	case CharBackspace:
 		o.ExitCompleteSelectMode()
 		next = false
 	case CharTab, CharForward:
-		o.doSelect()
+		o.nextCandidate(1)
 	case CharBell, CharInterrupt:
 		o.ExitCompleteMode(true)
 		next = false
 	case CharNext:
-		tmpChoise := o.candidateChoise + o.candidateColNum
+		colNum := 1
+		if o.candidateColNum > 1 {
+			colNum = o.candidateColNum
+		}
+		tmpChoise := o.candidateChoise + colNum
 		if tmpChoise >= o.getMatrixSize() {
 			tmpChoise -= o.getMatrixSize()
 		} else if tmpChoise >= len(o.candidate) {
-			tmpChoise += o.candidateColNum
+			tmpChoise += colNum
 			tmpChoise -= o.getMatrixSize()
 		}
 		o.candidateChoise = tmpChoise
 	case CharBackward:
 		o.nextCandidate(-1)
 	case CharPrev:
-		tmpChoise := o.candidateChoise - o.candidateColNum
+		colNum := 1
+		if o.candidateColNum > 1 {
+			colNum = o.candidateColNum 
+		}
+		tmpChoise := o.candidateChoise - colNum
 		if tmpChoise < 0 {
 			tmpChoise += o.getMatrixSize()
 			if tmpChoise >= len(o.candidate) {
-				tmpChoise -= o.candidateColNum
+				tmpChoise -= colNum
 			}
 		}
 		o.candidateChoise = tmpChoise
@@ -173,34 +215,62 @@ func (o *opCompleter) HandleCompleteSelect(r rune) bool {
 	return false
 }
 
+// HandlePagerMode handles user input when in pager mode.
+// The user can only press certain keys either viewing another
+// page or quitting the pager and going back to the prompt.
+// returns true if we are still in pager mode or false if
+// we exit pager mode.
+func (o *opCompleter) HandlePagerMode(r rune) (stayInMode bool) {
+	switch r {
+	case ' ', 'Y', 'y':                // yes, show me more
+		return o.pagerRefresh()    // last page exits
+	case 'q','Q', 'N', 'n':            // no, quit giving me more
+		o.scrollOutOfPagerMode()   // adjust for prompt
+		o.ExitCompleteMode(true)   // completely exit complete mode
+		return false
+	default:                           // invalid choice
+		o.op.t.Bell()              // ring bell
+		return true                // stay in pager mode
+	}
+}
+
 func (o *opCompleter) getMatrixSize() int {
-	line := len(o.candidate) / o.candidateColNum
-	if len(o.candidate)%o.candidateColNum != 0 {
+	colNum := 1
+	if o.candidateColNum > 1 {
+		colNum = o.candidateColNum
+	}
+	line := len(o.candidate) / colNum
+	if len(o.candidate) % colNum != 0 {
 		line++
 	}
-	return line * o.candidateColNum
+	return line * colNum
 }
 
 func (o *opCompleter) OnWidthChange(newWidth int) {
 	o.width = newWidth
 }
 
-func (o *opCompleter) CompleteRefresh() {
-	if !o.inCompleteMode {
-		return
-	}
-	lineCnt := o.op.buf.CursorLineCount()
+func (o *opCompleter) OnSizeChange(newWidth, newHeight int) {
+	o.width = newWidth
+	o.height = newHeight
+}
+
+// setColumnInfo calculates column width and number of columns required
+// to present the list of candidates on the terminal.
+func (o *opCompleter) setColumnInfo() {
+	same := o.op.buf.RuneSlice(-o.candidateOff)
+	sameWidth := runes.WidthAll(same)
+
 	colWidth := 0
 	for _, c := range o.candidate {
-		w := runes.WidthAll(c)
+		w := sameWidth + runes.WidthAll(c)
 		if w > colWidth {
 			colWidth = w
 		}
 	}
-	colWidth += o.candidateOff + 1
-	same := o.op.buf.RuneSlice(-o.candidateOff)
+	colWidth++ // whitespace between cols
 
-	// -1 to avoid reach the end of line
+	// -1 to avoid end of line issues
 	width := o.width - 1
 	colNum := width / colWidth
 	if colNum != 0 {
@@ -208,78 +278,233 @@ func (o *opCompleter) CompleteRefresh() {
 	}
 
 	o.candidateColNum = colNum
+	o.candidateColWidth = colWidth
+}
+
+// needPagerMode returns true if number of candidates would go off the page
+func (o *opCompleter) needPagerMode() bool {
+	buflineCnt := o.op.buf.LineCount()           // lines taken by buffer content
+	linesAvail := o.height - buflineCnt          // lines available without scrolling buffer off screen
+	if o.candidateColNum > 0 {
+		// Normal case where each candidate at least fits on a line
+		maxOrPage := linesAvail * o.candidateColNum  // max candiates without needing to page
+		return len(o.candidate) > maxOrPage
+	}
+
+	same := o.op.buf.RuneSlice(-o.candidateOff)
+	sameWidth := runes.WidthAll(same)
+
+	// 1 or more candidates take up multiple lines
+	lines := 1
+	for _, c := range o.candidate {
+		cWidth := sameWidth + runes.WidthAll(c)
+		cLines := 1
+		if o.width > 0 {
+			cLines = cWidth / o.width
+			if cWidth % o.width > 0 {
+				cLines++
+			}
+		}
+		lines += cLines
+		if lines > linesAvail {
+			return true
+		}
+	}
+	return false
+}
+
+// CompleteRefresh is used for completemode and selectmode
+func (o *opCompleter) CompleteRefresh() {
+	if !o.inCompleteMode {
+		return
+	}
+
 	buf := bufio.NewWriter(o.w)
-	buf.Write(bytes.Repeat([]byte("\n"), lineCnt))
+	// calculate num lines from cursor pos to where choices should be written
+	lineCnt := o.op.buf.CursorLineCount()
+	buf.Write(bytes.Repeat([]byte("\n"), lineCnt))  // move down from cursor to start of candidates
+	buf.WriteString("\033[J")
+
+	same := o.op.buf.RuneSlice(-o.candidateOff)
 
 	colIdx := 0
-	lines := 1
-	buf.WriteString("\033[J")
+	lines := 0
+	sameWidth := runes.WidthAll(same)
 	for idx, c := range o.candidate {
 		inSelect := idx == o.candidateChoise && o.IsInCompleteSelectMode()
+		cWidth := sameWidth + runes.WidthAll(c)
+		cLines := 1
+		if o.width > 0 {
+			sWidth := 0
+			if isWindows && inSelect {
+				sWidth = 1 // adjust for hightlighting on Windows
+			}
+			cLines = (cWidth + sWidth) / o.width
+			if (cWidth + sWidth) % o.width > 0 {
+				cLines++
+			}
+		}
+		if lines > 0 && colIdx == 0 {
+			// After line 1, if we're printing to the first column
+			// goto a new line. We do it here, instead of at the end
+			// of the loop, to avoid the last \n taking up a blank
+			// line at the end and stealing realestate.
+			buf.WriteString("\n")
+		}
+
 		if inSelect {
 			buf.WriteString("\033[30;47m")
 		}
+
 		buf.WriteString(string(same))
 		buf.WriteString(string(c))
-		buf.Write(bytes.Repeat([]byte(" "), colWidth-runes.WidthAll(c)-runes.WidthAll(same)))
+		if o.candidateColNum >= 1 {
+			// only output spaces between columns if everything fits
+			buf.Write(bytes.Repeat([]byte(" "), o.candidateColWidth - cWidth))
+		}
 
 		if inSelect {
 			buf.WriteString("\033[0m")
 		}
 
 		colIdx++
-		if colIdx == colNum {
-			buf.WriteString("\n")
-			lines++
+		if colIdx >= o.candidateColNum {
+			lines += cLines
 			colIdx = 0
+			if isWindows {
+				// Windows EOL edge-case.
+				buf.WriteString("\b")
+			}
 		}
 	}
+	if colIdx > 0 {
+		lines++  // mid-line so count it.
+	}
 
-	// move back
-	fmt.Fprintf(buf, "\033[%dA\r", lineCnt-1+lines)
-	fmt.Fprintf(buf, "\033[%dC", o.op.buf.idx+o.op.buf.PromptLen())
+	// wrote out choices over "lines", move back to cursor (positioned at index)
+	fmt.Fprintf(buf, "\033[%dA", lines)
+	buf.Write(o.op.buf.getBackspaceSequence())
 	buf.Flush()
 }
 
-func (o *opCompleter) aggCandidate(candidate [][]rune) int {
-	offset := 0
-	for i := 0; i < len(candidate[0]); i++ {
-		for j := 0; j < len(candidate)-1; j++ {
-			if i > len(candidate[j]) {
-				goto aggregate
-			}
-			if candidate[j][i] != candidate[j+1][i] {
-				goto aggregate
+// pagerRefresh writes a page full of candidates starting from candidateChoise to the screen
+// followed by --More-- if there are more candidates or exiting complete mode entirely if done
+// after which the prompt would be printed below the list (similar to bash). This is different
+// to CompleteMode and CompleteSelectMode which leave the prompt on the same page and need
+// to reset the cursor back up it after drawing the list.
+func (o *opCompleter) pagerRefresh() (stayInMode bool) {
+	buf := bufio.NewWriter(o.w)
+	firstPage := o.candidateChoise == 0
+	if firstPage {
+		o.op.buf.SetOffset("1;1")     // paging, so reset any prompt offset
+		// move down from cursor to where candidates should start
+		lineCnt := o.op.buf.CursorLineCount()
+		buf.Write(bytes.Repeat([]byte("\n"), lineCnt))
+	} else {
+		// after first page, redraw over --More--
+		buf.WriteString("\r")
+	}		
+	buf.WriteString("\033[J")   // clear anything below
+
+	same := o.op.buf.RuneSlice(-o.candidateOff)
+	sameWidth := runes.WidthAll(same)
+
+	colIdx := 0
+	lines := 1
+	for ; o.candidateChoise < len(o.candidate) ; o.candidateChoise++ {
+		c := o.candidate[o.candidateChoise]
+		cWidth := sameWidth + runes.WidthAll(c)
+		cLines := 1
+		if o.width > 0 {
+			cLines = cWidth / o.width
+			if cWidth % o.width > 0 {
+				cLines++
 			}
 		}
-		offset = i
+		if lines > 1 && lines + cLines > o.height {
+			break // won't fit on page, stop early.
+		}
+		buf.WriteString(string(same))
+		buf.WriteString(string(c))
+		if o.candidateColNum > 1 {
+			// only output spaces between columns if more than 1
+			buf.Write(bytes.Repeat([]byte(" "), o.candidateColWidth - cWidth))
+		}
+		colIdx++
+		if colIdx >= o.candidateColNum {
+			if isWindows {
+				// Windows EOL edge-case.
+				buf.WriteString("\b")
+			}
+			buf.WriteString("\n")
+			lines += cLines
+			colIdx = 0
+		}
 	}
-aggregate:
-	return offset
+	if colIdx != 0 {
+		buf.WriteString("\n")
+	}
+	if firstPage || o.candidateChoise < len(o.candidate) {
+		stayInMode = true
+		buf.WriteString("--More--")
+	} else {
+		stayInMode = false
+		o.scrollOutOfPagerMode()
+		o.ExitCompleteMode(true)
+	}
+	buf.Flush()
+	return
+}
+
+// scrollOutOfPagerMode adds enough new lines after the pager content such that when
+// we rewrite the prompt it does not over write the page content. The code to rewrite
+// the prompt assumes the cursor is at the index line, so we add enough blank lines.
+func (o *opCompleter) scrollOutOfPagerMode() {
+	lineCnt := o.op.buf.IdxLine(o.width)
+	if lineCnt > 0 {
+		buf := bufio.NewWriter(o.w)
+		buf.Write(bytes.Repeat([]byte("\n"), lineCnt))
+		buf.Flush()
+	}
 }
 
 func (o *opCompleter) EnterCompleteSelectMode() {
 	o.inSelectMode = true
 	o.candidateChoise = -1
-	o.CompleteRefresh()
 }
 
 func (o *opCompleter) EnterCompleteMode(offset int, candidate [][]rune) {
 	o.inCompleteMode = true
 	o.candidate = candidate
 	o.candidateOff = offset
-	o.CompleteRefresh()
+	o.setColumnInfo()
+	if o.needPagerMode() {
+		o.EnterPagerMode()
+	} else {
+		o.CompleteRefresh()
+	}
+}
+
+func (o *opCompleter) EnterPagerMode() {
+	o.inPagerMode = true
+	o.candidateChoise = 0   // next candidate to list on next page
+	o.pagerRefresh()
 }
 
 func (o *opCompleter) ExitCompleteSelectMode() {
 	o.inSelectMode = false
-	o.candidate = nil
 	o.candidateChoise = -1
-	o.candidateOff = -1
-	o.candidateSource = nil
 }
 
 func (o *opCompleter) ExitCompleteMode(revent bool) {
 	o.inCompleteMode = false
+	o.candidate = nil
+	o.candidateOff = -1
+	o.candidateSource = nil
 	o.ExitCompleteSelectMode()
+	o.ExitPagerMode()
+}
+
+func (o *opCompleter) ExitPagerMode() {
+	o.inPagerMode = false
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/chzyer/test v1.0.0
 	golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5
+	golang.org/x/text v0.3.7
 )
 
 require github.com/chzyer/logex v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,6 @@ github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 h1:y/woIyUBFbpQGKS0u1aHF/40WUDnek3fPOyD08H5Vng=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/operation.go
+++ b/operation.go
@@ -232,6 +232,7 @@ func (o *Operation) ioloop() {
 			o.Refresh()
 		case CharCtrlL:
 			ClearScreen(o.w)
+			o.buf.SetOffset("1;1")
 			o.Refresh()
 		case MetaBackspace, CharCtrlW:
 			o.buf.BackEscapeWord()
@@ -385,8 +386,14 @@ func (o *Operation) Runes() ([]rune, error) {
 		listener.OnChange(nil, 0, 0)
 	}
 
-	o.buf.Refresh(nil) // print prompt
+	// Query cursor position before printing the prompt as there
+	// maybe existing text on the same line that ideally we don't
+	// want to overwrite and cause prompt to jump left. Note that
+	// this is not perfect but works the majority of the time.
+	o.buf.getAndSetOffset(o.t)
+	o.buf.Print() // print prompt & buffer contents
 	o.t.KickRead()
+
 	select {
 	case r := <-o.outchan:
 		return r, nil

--- a/readline.go
+++ b/readline.go
@@ -54,7 +54,9 @@ type Config struct {
 	InterruptPrompt string
 	EOFPrompt       string
 
-	FuncGetWidth func() int
+	FuncGetWidth    func() int
+	// Function that returns width, height of the terminal or -1,-1 if unknown
+	FuncGetSize     func() (width int, height int)
 
 	Stdin       io.ReadCloser
 	StdinWriter io.Writer
@@ -130,6 +132,9 @@ func (c *Config) Init() error {
 	if c.FuncGetWidth == nil {
 		c.FuncGetWidth = GetScreenWidth
 	}
+	if c.FuncGetSize == nil {
+		c.FuncGetSize = GetScreenSize
+	}
 	if c.FuncIsTerminal == nil {
 		c.FuncIsTerminal = DefaultIsTerminal
 	}
@@ -141,7 +146,7 @@ func (c *Config) Init() error {
 		c.FuncExitRaw = rm.Exit
 	}
 	if c.FuncOnWidthChanged == nil {
-		c.FuncOnWidthChanged = DefaultOnWidthChanged
+		c.FuncOnWidthChanged = DefaultOnSizeChanged
 	}
 
 	return nil

--- a/runes.go
+++ b/runes.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"unicode"
 	"unicode/utf8"
+	"golang.org/x/text/width"
 )
 
 var runes = Runes{}
@@ -150,10 +151,12 @@ func (Runes) Width(r rune) int {
 	if unicode.IsOneOf(zeroWidth, r) {
 		return 0
 	}
-	if unicode.IsOneOf(doubleWidth, r) {
+	switch width.LookupRune(r).Kind() {
+	case width.EastAsianWide, width.EastAsianFullwidth:
 		return 2
+	default:
+		return 1
 	}
-	return 1
 }
 
 func (Runes) WidthAll(r []rune) (length int) {

--- a/runes_test.go
+++ b/runes_test.go
@@ -10,16 +10,52 @@ type twidth struct {
 	length int
 }
 
+func TestSingleRuneWidth(t *testing.T) {
+        type test struct {
+                r  rune
+                w  int
+        }
+
+        tests := []test{
+		{0, 0},             // default rune is 0 - default mask
+		{'a', 1},
+		{'☭', 1},
+		{'你', 2},
+		{'日', 2},          // kanji
+		{'ｶ', 1},           // half-width katakana
+		{'カ', 2},          // full-width katakana
+		{'ひ', 2},          // full-width hiragana 
+		{'Ｗ', 2},          // full-width romanji
+		{'）', 2},          // full-width symbols
+		{'😅', 2},          // emoji
+        }
+
+        for _, test := range tests {
+		if w := runes.Width(test.r); w != test.w {
+			t.Error("result is not expected", string(test.r), test.w, w)
+		}
+	}
+}
+
 func TestRuneWidth(t *testing.T) {
 	rs := []twidth{
+		{[]rune(""), 0},
 		{[]rune("☭"), 1},
 		{[]rune("a"), 1},
 		{[]rune("你"), 2},
 		{runes.ColorFilter([]rune("☭\033[13;1m你")), 3},
+		{[]rune("漢字"), 4},           // kanji
+		{[]rune("ｶﾀｶﾅ"), 4},           // half-width katakana
+		{[]rune("カタカナ"), 8},       // full-width katakana
+		{[]rune("ひらがな"), 8},       // full-width hiragana 
+		{[]rune("ＷＩＤＥ"), 8},       // full-width romanji
+		{[]rune("ー。"), 4},           // full-width symbols
+		{[]rune("안녕하세요"), 10},    // full-width Hangul
+		{[]rune("😅"), 2},             // emoji
 	}
 	for _, r := range rs {
 		if w := runes.WidthAll(r.r); w != r.length {
-			t.Fatal("result not expect", r.r, r.length, w)
+			t.Error("result is not expected", string(r.r), r.length, w)
 		}
 	}
 }

--- a/search.go
+++ b/search.go
@@ -30,20 +30,26 @@ type opSearch struct {
 	markStart int
 	markEnd   int
 	width     int
+	height    int
 }
 
-func newOpSearch(w io.Writer, buf *RuneBuffer, history *opHistory, cfg *Config, width int) *opSearch {
+func newOpSearch(w io.Writer, buf *RuneBuffer, history *opHistory, cfg *Config, width int, height int) *opSearch {
 	return &opSearch{
 		w:       w,
 		buf:     buf,
 		cfg:     cfg,
 		history: history,
 		width:   width,
+		height:  height,
 	}
 }
 
 func (o *opSearch) OnWidthChange(newWidth int) {
 	o.width = newWidth
+}
+func (o *opSearch) OnSizeChange(newWidth, newHeight int) {
+	o.width = newWidth
+	o.height = newHeight
 }
 
 func (o *opSearch) IsSearchMode() bool {

--- a/terminal.go
+++ b/terminal.go
@@ -80,7 +80,7 @@ func (t *Terminal) GetOffset(f func(offset string)) {
 	go func() {
 		f(<-t.sizeChan)
 	}()
-	t.Write([]byte("\033[6n"))
+	SendCursorPosition(t)
 }
 
 func (t *Terminal) Print(s string) {

--- a/utils.go
+++ b/utils.go
@@ -212,21 +212,29 @@ func escapeKey(r rune, reader *bufio.Reader) rune {
 	return r
 }
 
-func SplitByLine(start, screenWidth int, rs []rune) []string {
-	var ret []string
-	buf := bytes.NewBuffer(nil)
-	currentWidth := start
-	for _, r := range rs {
+// split prompt + runes into lines by screenwidth starting from an offset.
+// the prompt should be filtered before passing to only its display runes.
+// if you know the width of the next character, pass it in as it is used
+// to decide if we generate an extra empty rune array to show next is new
+// line.
+func SplitByLine(prompt, rs []rune, offset, screenWidth, nextWidth int) [][]rune {
+	ret := make([][]rune, 0)
+	prs := append(prompt, rs...)
+	si := 0
+	currentWidth := offset
+	for i, r := range prs {
 		w := runes.Width(r)
-		currentWidth += w
-		buf.WriteRune(r)
-		if currentWidth >= screenWidth {
-			ret = append(ret, buf.String())
-			buf.Reset()
+		if currentWidth + w > screenWidth {
+			ret = append(ret, prs[si:i])
+			si = i
 			currentWidth = 0
 		}
+		currentWidth += w
 	}
-	ret = append(ret, buf.String())
+	ret = append(ret, prs[si:len(prs)])
+	if currentWidth + nextWidth > screenWidth {
+		ret = append(ret, []rune{})
+	}
 	return ret
 }
 

--- a/utils_unix.go
+++ b/utils_unix.go
@@ -44,6 +44,12 @@ func GetScreenWidth() int {
 	return w
 }
 
+// Ask the terminal for the current cursor position. The terminal will then
+// write the position back to us via termainal stdin asynchronously.
+func SendCursorPosition(t *Terminal) {
+	t.Write([]byte("\033[6n"))
+}
+
 // ClearScreen clears the console screen
 func ClearScreen(w io.Writer) (int, error) {
 	return w.Write([]byte("\033[H"))

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -28,6 +28,17 @@ func GetScreenWidth() int {
 	return int(info.dwSize.x)
 }
 
+// GetScreenSize returns the width, height of the terminal or -1,-1
+func GetScreenSize() (width int, height int) {
+	info, _ := GetConsoleScreenBufferInfo()
+	if info == nil {
+		return -1, -1
+	}
+	height = int(info.srWindow.bottom) - int(info.srWindow.top) + 1
+	width = int(info.srWindow.right) - int(info.srWindow.left) + 1
+	return
+}
+
 // Send the Current cursor position to t.sizeChan.
 func SendCursorPosition(t *Terminal) {
 	info, err := GetConsoleScreenBufferInfo()
@@ -47,6 +58,10 @@ func DefaultIsTerminal() bool {
 	return true
 }
 
-func DefaultOnWidthChanged(func()) {
+func DefaultOnWidthChanged(f func()) {
+	DefaultOnSizeChanged(f)
+}
+
+func DefaultOnSizeChanged(f func()) {
 
 }

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -3,6 +3,7 @@
 package readline
 
 import (
+	"fmt"
 	"io"
 	"syscall"
 )
@@ -25,6 +26,16 @@ func GetScreenWidth() int {
 		return -1
 	}
 	return int(info.dwSize.x)
+}
+
+// Send the Current cursor position to t.sizeChan.
+func SendCursorPosition(t *Terminal) {
+	info, err := GetConsoleScreenBufferInfo()
+	if err != nil || info == nil {
+		t.sizeChan <- "-1;-1"
+	} else {
+		t.sizeChan <- fmt.Sprintf("%d;%d", info.dwCursorPosition.y, info.dwCursorPosition.x)
+	}
 }
 
 // ClearScreen clears the console screen


### PR DESCRIPTION
NB: This PR includes PR202 (https://github.com/chzyer/readline/pull/202) which is not yet merged. PR202 addressed various redraw issues with wide characters, edge of screen, multiple lines, masking etc. The main feature of the pager builds on these changes and redraw code so, I had to include them in this PR.

Main Features:
- If there are too many candidates returned by the completer, completeMode and completeSelectMode did not work properly. Similar to the bash completion pager, list candidates and offer "--More--" on the end of each page. User can select " ", "y" or "Y" to keep listing or "q", "Q", "n", "N" to stop listing. When paging completes, we also exit out of completionMode.
- Added aggregate completion when entering completeSelectMode where the candidates dwindle down sharing a larger common prefix. This makes typing a little faster than having to select. It's a more bash-like behaviour.

Other Fixes:
- Fix various crashes where candidates are too wide for the width of the screen and causes division by zero.
- Fix crash with wide (Asian characters) in completion.
- Streamline redrawing as CompleteRefresh was called too often.
- Fix crashes around ctrl-a and ctrl-b in select mode when candidates don't fit on a line
- Fix prev/next candidates in select mode when candidates don't fit on a line
- Fix crash when ctrl-k was pressed in select mode. This caused us to exit completeSelectMode which cleaned up all the data but left us in completeMode such that if CompleteRefresh was called directly, the data was not initialised.
- Fix complete and select mode redraw issues when candidates did not fit on one line.
- Fix cursor position issues after CompleteRefresh especially if the prompt and buffer also went over 1 line.
- Fix redraw issue where exiting completion mode using certain key presses leaves candidates on the screen.

Fixes for Windows:
- Use window size for visible height/width instead of buffer size
- Adjust for Window's EOL behaviour.

Notes:
- Added Height info to different structures as the decision to page or not required height information.
- Added OnSizeChange(). Didn't know if I could get rid of the OnWidthChange()? Would be nice to remove the Width stuff and just have Size (width + height info).

I tested this patch on Linux and Window and it seems to work well.