### PR TITLE
Fixed: Autocomplete adds unwanted space (ASCII 32)(Issue #190)

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -123,7 +123,9 @@ func (o *opCompleter) HandleCompleteSelect(r rune) bool {
 	switch r {
 	case CharEnter, CharCtrlJ:
 		next = false
-		o.op.buf.WriteRunes(o.op.candidate[o.op.candidateChoise])
+		target := o.op.candidate[o.op.candidateChoise]
+		target = target[:len(target)-1]
+		o.op.buf.WriteRunes()
 		o.ExitCompleteMode(false)
 	case CharLineStart:
 		num := o.candidateChoise % o.candidateColNum


### PR DESCRIPTION
I made a small adjustment to complete.go which removes the additional space that gets added to the tab completions 