### PR TITLE
 Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives me time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to git@0xdf.com; and/or
+- send me a [private vulnerability report](https://github.com/chzyer/readline/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by a single developer on a reasonable-effort basis. As such,
+please give me at least 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #223

As per the linked issue, this PR adds a security policy to the repository.

The policy currently requests that vulnerabilities be reported to git [at] 0xdf.com (copied from @chzyer's GH profile) or using GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository) feature (currently in beta).

If you wish to use another email or just one of these alternatives, let me know and I'll gladly modify the document.