### PR TITLE
Add support for zOS

### DIFF
--- a/term.go
+++ b/term.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd os400 solaris
+// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd os400 solaris zos
 
 // Package terminal provides support functions for dealing with terminals, as
 // commonly found on UNIX systems.

--- a/term_nosyscall6.go
+++ b/term_nosyscall6.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build aix os400 solaris
+// +build aix os400 solaris zos
 
 package readline
 

--- a/utils_unix.go
+++ b/utils_unix.go
@@ -1,4 +1,4 @@
-// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd os400 solaris
+// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd os400 solaris zos
 
 package readline
 


### PR DESCRIPTION
Hi,

Firstly, thank you for this excellent project!

In this PR, I've updated the build tags in a few files to add support for zOS, which is an IBM Z (aka mainframe) operating system.

Test results look like this:
```go
tmpdir: /tmp
=== RUN   TestRetSegment
--- PASS: TestRetSegment (0.00s)
=== RUN   TestSplitSegment
--- PASS: TestSplitSegment (0.00s)
=== RUN   TestSegmentCompleter
--- PASS: TestSegmentCompleter (0.00s)
=== RUN   TestRace
--- PASS: TestRace (0.00s)
=== RUN   TestRuneWidth
--- PASS: TestRuneWidth (0.00s)
=== RUN   TestAggRunes
--- PASS: TestAggRunes (0.00s)
PASS
ok  	github.com/chzyer/readline	1.018s
?   	github.com/chzyer/readline/example/readline-demo	[no test files]
?   	github.com/chzyer/readline/example/readline-im	[no test files]
?   	github.com/chzyer/readline/example/readline-multiline	[no test files]
?   	github.com/chzyer/readline/example/readline-pass-strength	[no test files]
?   	github.com/chzyer/readline/example/readline-remote/readline-remote-client	[no test files]
?   	github.com/chzyer/readline/example/readline-remote/readline-remote-server	[no test files]
=== RUN   TestRuneWidth
--- PASS: TestRuneWidth (0.00s)
=== RUN   TestAggRunes
--- PASS: TestAggRunes (0.00s)
PASS
ok  	github.com/chzyer/readline/runes	0.410s
```


... and the output from examples look like this:

```shell
$ cd readline-demo && go run .
» enhance
2023/05/28 01:05:08 you said: "enhance"
» mode
current mode: emacs
» login
please enter your password: 
you enter: "boo"
» sleep
2023/05/28 01:06:15 sleep 4 second
» bye


$ cd ../readline-im && go run .
Hi, loopy! My name is Dave.
2023/05/28 01:07:39 Dave: hello
2023/05/28 01:07:41 Dave: hello
.
.
2023/05/28 01:08:44 Dave: bye


$ cd ../readline-multiline && go run .
> why
>>> test
>>> me;
why test me;
> bye;
bye;


$ cd ../readline-pass-strength && go run .
✔ ENT New Password: 
Your password was: toostrong
⚠ ENT New Password: 
Your password was: lame



```