### PR TITLE
adds Config option to disable bell; DisableBell

### DIFF
--- a/readline.go
+++ b/readline.go
@@ -1,20 +1,20 @@
 // Readline is a pure go implementation for GNU-Readline kind library.
 //
 // example:
-// 	rl, err := readline.New("> ")
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	defer rl.Close()
 //
-// 	for {
-// 		line, err := rl.Readline()
-// 		if err != nil { // io.EOF
-// 			break
-// 		}
-// 		println(line)
-// 	}
+//	rl, err := readline.New("> ")
+//	if err != nil {
+//		panic(err)
+//	}
+//	defer rl.Close()
 //
+//	for {
+//		line, err := rl.Readline()
+//		if err != nil { // io.EOF
+//			break
+//		}
+//		println(line)
+//	}
 package readline
 
 import (
@@ -67,6 +67,8 @@ type Config struct {
 	// erase the editing line after user submited it
 	// it use in IM usually.
 	UniqueEditLine bool
+
+	DisableBell bool
 
 	// filter input runes (may be used to disable CtrlZ or for translating some keys to different actions)
 	// -> output = new (translated) rune and true/false if continue with processing this one
@@ -301,9 +303,10 @@ func (i *Instance) Write(b []byte) (int, error) {
 // WriteStdin prefill the next Stdin fetch
 // Next time you call ReadLine() this value will be writen before the user input
 // ie :
-//  i := readline.New()
-//  i.WriteStdin([]byte("test"))
-//  _, _= i.Readline()
+//
+//	i := readline.New()
+//	i.WriteStdin([]byte("test"))
+//	_, _= i.Readline()
 //
 // gives
 //

--- a/terminal.go
+++ b/terminal.go
@@ -214,7 +214,9 @@ func (t *Terminal) ioloop() {
 }
 
 func (t *Terminal) Bell() {
-	fmt.Fprintf(t, "%c", CharBell)
+	if !t.cfg.DisableBell {
+		fmt.Fprintf(t, "%c", CharBell)
+	}
 }
 
 func (t *Terminal) Close() error {


### PR DESCRIPTION
In my app, I'd like to disable the bell programmatically. It seems that making that a config option makes sense and someone else might also want to do so.

The whitespace changes are a result of gofmt.