### PR TITLE
buildtag changes for z/OS

### DIFF
--- a/term.go
+++ b/term.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd os400 solaris
+// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd os400 solaris zos
 
 // Package terminal provides support functions for dealing with terminals, as
 // commonly found on UNIX systems.

--- a/term_nosyscall6.go
+++ b/term_nosyscall6.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build aix os400 solaris
+// +build aix os400 solaris zos
 
 package readline
 

--- a/utils_unix.go
+++ b/utils_unix.go
@@ -1,4 +1,4 @@
-// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd os400 solaris
+// +build aix darwin dragonfly freebsd linux,!appengine netbsd openbsd os400 solaris zos
 
 package readline
 


### PR DESCRIPTION
This PR enables readline to be built on z/OS

unit test passed:
```
bash-5.2$ go test .
ok  	github.com/chzyer/readline	(cached)
```