### PR TITLE
feat: Support pagination for tab completion

### DIFF
--- a/example/readline-paged-completion/readline-paged-completion.go
+++ b/example/readline-paged-completion/readline-paged-completion.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"strconv"
+	"strings"
+
+	"github.com/chzyer/readline"
+)
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randSeq(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+// A completor that will give a lot of completions for showcasing the paging functionality
+type Completor struct{}
+
+func (c *Completor) Do(line []rune, pos int) ([][]rune, int) {
+	completion := make([][]rune, 0, 10000)
+	for i := range 10000 {
+		s := fmt.Sprintf("%s%020d", randSeq(1), i)
+		completion = append(completion, []rune(s))
+	}
+	return completion, pos
+}
+
+func main() {
+	c := Completor{}
+	l, err := readline.NewEx(&readline.Config{
+		Prompt:          "\033[31m»\033[0m ",
+		AutoComplete:    &c,
+		InterruptPrompt: "^C",
+		EOFPrompt:       "exit",
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer l.Close()
+	for {
+		line, err := l.Readline()
+		if err == readline.ErrInterrupt {
+			if len(line) == 0 {
+				break
+			} else {
+				continue
+			}
+		} else if err == io.EOF {
+			break
+		}
+
+		line = strings.TrimSpace(line)
+		switch {
+		default:
+			log.Println("you said:", strconv.Quote(line))
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chzyer/readline
 
-go 1.15
+go 1.22
 
 require (
 	github.com/chzyer/test v1.0.0

--- a/utils.go
+++ b/utils.go
@@ -46,6 +46,8 @@ const (
 	CharO         = 79
 	CharEscapeEx  = 91
 	CharBackspace = 127
+	CharK         = 107
+	CharJ         = 106
 )
 
 const (


### PR DESCRIPTION
Hy @chzyer Don't know if this repo is still maintained, but we are using it for a command-line application that would need to tab-complete many choices (think ~1000), and the current implementation could not put those nicely on the terminal. I hacked a little feature to put the completions in pages and allow users to navigate pages using `J` and `K` keys in selection mode. 

I tested it for my workflow and it worked fine (I added an example `readline-paged-completion` to showcase the feature, but I have not tested it thoroughly (e.g., vim mode and other stuff).