### PR TITLE
Update readline-demo.go to remove deprecated io/ioutil

### DIFF
--- a/example/readline-demo/readline-demo.go
+++ b/example/readline-demo/readline-demo.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"strconv"
 	"strings"
@@ -21,7 +20,7 @@ func usage(w io.Writer) {
 func listFiles(path string) func(string) []string {
 	return func(line string) []string {
 		names := make([]string, 0)
-		files, _ := ioutil.ReadDir(path)
+		files, _ := os.ReadDir(path)
 		for _, f := range files {
 			names = append(names, f.Name())
 		}


### PR DESCRIPTION
Super simple change, but happened to catch this when I was looking into the package. io/ioutil has been deprecated since Go 1.16 and os.ReadDir is now the equivalent function. Demo code still works as intended.