### PR TITLE
Fix SetTitle escape sequence to use correct OSC format

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -424,7 +424,7 @@ func (o *Operation) Password(prompt string) ([]byte, error) {
 }
 
 func (o *Operation) SetTitle(t string) {
-	o.w.Write([]byte("\033[2;" + t + "\007"))
+	o.w.Write([]byte("\033]2;" + t + "\007"))
 }
 
 func (o *Operation) Slice() ([]byte, error) {


### PR DESCRIPTION
### Problem
The `SetTitle` method uses an incorrect escape sequence that causes the title text to appear in the terminal output instead of setting the window title.

### Root Cause
- Current: `\033[2;` (CSI - Control Sequence Introducer)
- Correct: `\033]2;` (OSC - Operating System Command)

### Fix
Changed `[` to `]` in the escape sequence to use the proper OSC format for setting terminal window titles.

### Testing
Verified the fix resolves text bleeding in multiple terminal emulators.