### PR TITLE
Handle wide characters in getBackspaceSequence

### DIFF
--- a/runebuf.go
+++ b/runebuf.go
@@ -528,7 +528,10 @@ func (r *RuneBuffer) getBackspaceSequence() []byte {
 	var buf []byte
 	for i := len(r.buf); i > r.idx; i-- {
 		// move input to the left of one
-		buf = append(buf, '\b')
+		runeWidth := runes.Width(r.buf[i-1])
+		for j := 0; j < runeWidth; j++ {
+			buf = append(buf, '\b')
+		}
 		if sep[i] {
 			// up one line, go to the start of the line and move cursor right to the end (r.width)
 			buf = append(buf, "\033[A\r"+"\033["+strconv.Itoa(r.width)+"C"...)


### PR DESCRIPTION
- Output the correct number of backspace characters for each rune based on its display width (using runes.Width), ensuring proper cursor movement for wide/fullwidth characters.
- Retain multi-line and line start/end handling logic.

Fixes #184