### PR TITLE
Only use RawReader on Windows if stdin is a console

### DIFF
--- a/std_windows.go
+++ b/std_windows.go
@@ -3,7 +3,11 @@
 package readline
 
 func init() {
-	Stdin = NewRawReader()
+	// don't use RawReader if stdin is a pipe (see https://github.com/chzyer/readline/issues/229)
+	stdinType, _ := kernel.GetFileType(stdin)
+	if stdinType == FILE_TYPE_CHAR {
+		Stdin = NewRawReader()
+	}
 	Stdout = NewANSIWriter(Stdout)
 	Stderr = NewANSIWriter(Stderr)
 }


### PR DESCRIPTION
Fixes #229

FYI: This uses the `syscall.SyscallN` function (instead of the deprecated Syscall5, etc.) to simplify the code a bit. That function was introduced in go1.18. I'm not sure if there is any desire to support compiling this library on older versions of go (I see `go 1.15` is set in `go.mod` but that seems to only affect syntax), but if there is I can switch it back to the deprecated methods.