### PR TITLE
Added missing 'os' import to readline-demo.go. It didn't build otherwise

### DIFF
--- a/example/readline-demo/readline-demo.go
+++ b/example/readline-demo/readline-demo.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 	"time"


### PR DESCRIPTION
Maybe this was missed in #242  when changing ioutil.ReadDir to os.ReadDir
Didn't build/run for me unless I added the os import